### PR TITLE
Add cargo-husky pre-push hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1183,7 @@ dependencies = [
  "async-openai",
  "async-recursion",
  "async-trait",
+ "cargo-husky",
  "console",
  "derive_builder",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ indicatif = "0.18.4"
 console = "0.16.2"
 derive_builder = "0.20.2"
 
+[dev-dependencies]
+cargo-husky = { version = "1.5.0", default-features = false, features = ["prepush-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"] }
+
 [[example]]
 name = "cli"
 path = "examples/cli.rs"


### PR DESCRIPTION
## Summary
- add cargo-husky as a dev dependency
- configure pre-push checks for cargo fmt --check, cargo clippy -- -D warnings, and cargo test
- no code changes

would fire on push, would help keep cb clean etc for the future, did not run on code as it would make a large diff