### PR TITLE
docs: AGENTS.md and core architecture documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# looper-rs
+
+A headless, UI-agnostic agentic loop for Rust. Provides streaming and non-streaming APIs with multi-provider LLM support (OpenAI, Anthropic, Gemini).
+
+## Where to Start
+
+- **Quick usage**: [`README.md`](./README.md)
+- **Architecture**: [`docs/core-agent-loop-architecture.md`](./docs/core-agent-loop-architecture.md)
+- **Example integration**: [`examples/cli.rs`](./examples/cli.rs)
+
+## Repository Map
+
+```
+src/
+├── lib.rs                    # Public module exports
+├── looper.rs                 # Non-streaming API: Looper, LooperBuilder
+├── looper_stream.rs          # Streaming API: LooperStream, LooperStreamBuilder
+├── types/                    # Shared contracts
+│   ├── messages.rs           # MessageHistory, event types
+│   ├── tool.rs               # LooperToolDefinition
+│   ├── handlers.rs           # Handlers enum, provider selection
+│   └── turn.rs               # TurnResult, TurnStep
+├── services/                 # Provider execution layer
+│   ├── chat_handler.rs       # ChatHandler trait (non-streaming)
+│   ├── chat_handler_streaming.rs  # StreamingChatHandler trait
+│   └── handlers/             # Provider implementations
+│       ├── openai_*.rs       # OpenAI Completions/Responses
+│       ├── anthropic*.rs     # Anthropic handlers
+│       └── gemini*.rs        # Gemini handlers
+├── mapping/                  # SDK translation layer
+│   └── tools/                # Tool definition mappings per provider (src/mapping/tools/)
+└── tools/                    # Tool contract and built-ins
+    ├── mod.rs                # LooperTool, LooperTools traits
+    ├── empty.rs              # EmptyToolSet fallback
+    └── sub_agent.rs          # SubAgentTool for delegation
+
+docs/
+├── core-agent-loop-architecture.md   # Control flow and invariants
+├── services-layer.md                 # Handler contracts
+├── tools-layer.md                    # Tool registry patterns
+└── mapping-layer.md                  # SDK translation details
+
+examples/
+├── cli.rs                  # Streaming CLI with tools
+└── cli_non_streaming.rs    # Simple blocking example
+
+prompts/
+└── system_prompt.txt       # Tera template for agent instructions
+```
+
+## Build, Test, Run
+
+```bash
+# Build
+cargo build
+
+# Run tests
+cargo test
+
+# Run examples
+cargo run --example cli
+cargo run --example cli_non_streaming
+
+# Lint/format (enforced via cargo-husky prepush hook)
+cargo clippy
+cargo fmt
+```
+
+## Architecture Boundaries
+
+| Layer | Responsibility | Key Files |
+|-------|---------------|-----------|
+| **Entry** | Builder API, public surface | `looper.rs`, `looper_stream.rs` |
+| **Services** | Provider SDK interaction | `services/handlers/*.rs` |
+| **Mapping** | Tool schema translation | `mapping/tools/*.rs` |
+| **Tools** | Tool execution registry | `tools/mod.rs` |
+| **Types** | Shared contracts | `types/*.rs` |
+
+## Provider Handlers
+
+All handlers follow the same recursion pattern: send request → parse response → execute tools → recurse until no tool calls remain.
+
+| Provider | Streaming | Non-streaming |
+|----------|-----------|---------------|
+| OpenAI Completions | `OpenAICompletionsHandler` | `OpenAICompletionsNonStreamingHandler` |
+| OpenAI Responses | `OpenAIResponsesHandler` | `OpenAIResponsesNonStreamingHandler` |
+| Anthropic | `AnthropicHandler` | `AnthropicNonStreamingHandler` |
+| Gemini | `GeminiHandler` | `GeminiNonStreamingHandler` |
+
+## Key Docs
+
+| Doc | Purpose |
+|-----|---------|
+| [`docs/core-agent-loop-architecture.md`](./docs/core-agent-loop-architecture.md) | Turn lifecycle, event flow, invariants |
+| [`docs/services-layer.md`](./docs/services-layer.md) | Handler contracts and provider patterns |
+| [`docs/tools-layer.md`](./docs/tools-layer.md) | Tool trait design and registry patterns |
+| [`docs/mapping-layer.md`](./docs/mapping-layer.md) | SDK translation layer |
+
+## Change Rules
+
+1. **New provider**: Add handler in `services/handlers/`, implement both streaming + non-streaming traits, add tool mapping in `mapping/tools/`
+2. **New tool**: Implement `LooperTool` trait, register in your `LooperTools` impl (see `examples/cli.rs` for pattern)
+3. **API changes**: Update both `Looper` and `LooperStream` builders if shared options affected
+4. **History models**: `MessageHistory::Messages` (OpenAI Completions, Anthropic, Gemini) vs `MessageHistory::ResponseId` (OpenAI Responses) — do not mix
+
+## Validation Checklist
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy` clean
+- [ ] `cargo fmt` clean
+- [ ] Examples compile: `cargo build --examples`
+- [ ] New paths added to this file if user-facing

--- a/docs/core-agent-loop-architecture.md
+++ b/docs/core-agent-loop-architecture.md
@@ -1,0 +1,161 @@
+---
+title: "Core Agent Loop Architecture"
+when_to_read:
+  - "When you need to understand how a user message becomes model output, tool calls, and updated history."
+  - "When you are adding a new provider handler, changing tool execution, or wiring a UI to streamed events."
+summary: "`looper-rs` is a provider-agnostic agent loop with two entry points: `Looper` for complete turn results and `LooperStream` for incremental UI events. This page explains the shared control flow, where providers diverge, and which invariants matter when you extend the crate or debug a broken turn."
+ontology_relations:
+  - relation: "depends_on"
+    target: "src/types"
+    note: "The shared message, tool, handler, and turn types define the contracts described here."
+  - relation: "depends_on"
+    target: "prompts/system_prompt.txt"
+    note: "Every handler receives the rendered system prompt built from this template."
+  - relation: "feeds"
+    target: "examples/cli.rs"
+    note: "The streaming CLI consumes the event semantics explained in this document."
+  - relation: "feeds"
+    target: "examples/cli_non_streaming.rs"
+    note: "The non-streaming CLI displays the `TurnResult` shape explained here."
+---
+
+# Purpose
+
+Explain the crate's real execution model: how builders create provider-specific handlers, how a turn recurses through tool calls, how history is persisted, and where the streaming and non-streaming APIs differ.
+
+# Scope
+
+This page covers the hot path through:
+
+- `src/looper.rs`
+- `src/looper_stream.rs`
+- `src/services/chat_handler*.rs`
+- `src/services/handlers/*`
+- `src/tools/*`
+- `src/types/*`
+- `src/mapping/tools/*`
+
+It does not try to document each upstream SDK. It also does not treat `src/mapping/turn/*` as core runtime behavior, because the current handlers build `TurnStep` values directly instead of using those conversions.
+
+# Main content
+
+## Core structure
+
+There are four layers in the crate:
+
+1. Entry points:
+   `Looper` is the non-streaming API. It returns a `TurnResult` after the full agent loop finishes.
+   `LooperStream` is the streaming API. It returns updated `MessageHistory` and emits `LooperToInterfaceMessage` events during the turn.
+2. Provider handlers:
+   `ChatHandler` and `StreamingChatHandler` are the provider-agnostic traits.
+   Concrete handlers in `src/services/handlers/*` implement the actual SDK calls for OpenAI Completions, OpenAI Responses, Anthropic, and Gemini.
+3. Tool execution:
+   `LooperTool` defines one callable tool.
+   `LooperTools` is the tool registry and execution surface the handlers call back into.
+4. Shared state:
+   `MessageHistory` stores conversation continuity.
+   `TurnResult` and `TurnStep` are the non-streaming reconstruction of what happened inside a turn.
+
+## Flow / behavior
+
+1. Build time
+
+   `Looper::builder(...)` and `LooperStream::builder(...)` choose a provider enum from `Handlers` and instantiate the matching handler.
+
+   Both builders render `prompts/system_prompt.txt` through Tera. That template optionally injects:
+
+   - caller-supplied instructions
+   - sub-agent guidance when `.sub_agent(...)` was configured
+
+   If a tool registry was supplied, the builder passes provider-specific tool definitions into the handler. The conversion from `LooperToolDefinition` into each SDK's tool schema happens in `src/mapping/tools/*`.
+
+   If `.sub_agent(...)` was set and a mutable tool registry exists, the builder adds `SubAgentTool` before handing tool definitions to the handler.
+
+2. Turn start
+
+   `send(...)` on either entry point passes three things into the selected handler:
+
+   - prior `MessageHistory`
+   - the new user message
+   - a shared `Arc<dyn LooperTools>` runner
+
+   The handler restores provider-specific history before appending the new user input.
+
+3. Model request
+
+   Each handler sends the current conversation plus tool definitions to the provider.
+
+   Provider-specific continuity differs:
+
+   - OpenAI Responses uses `MessageHistory::ResponseId` and relies on server-side response chaining via `previous_response_id`.
+   - OpenAI Completions, Anthropic, and Gemini use `MessageHistory::Messages`, which is a serialized SDK message vector stored locally as `serde_json::Value`.
+
+4. Model output handling
+
+   The handlers inspect the returned response for:
+
+   - assistant text
+   - thinking or reasoning content
+   - tool calls
+
+   Streaming handlers emit `HandlerToLooperMessage` events as tokens or blocks arrive. `LooperStream` optionally forwards those events to the UI and can buffer assistant text for smoother character-by-character rendering.
+
+   Non-streaming handlers accumulate one `TurnStep` per provider round-trip. A step may contain:
+
+   - zero or more thinking blocks
+   - optional assistant text
+   - zero or more tool call records with both args and results
+
+5. Tool execution
+
+   When a provider returns tool calls, the handler executes them concurrently with `tokio::task::JoinSet`.
+
+   The flow is:
+
+   - collect the fully materialized tool call
+   - send a streaming request event when applicable
+   - run each tool against `LooperTools::run_tool(...)`
+   - append provider-specific tool result messages back into history
+   - recursively call the same handler again
+
+   This recursion continues until a provider response contains no more tool calls.
+
+6. Turn completion
+
+   `Looper` stores the returned history and exposes:
+
+   - `steps`: every provider round-trip in the completed loop
+   - `final_text`: the last step that contained assistant text
+   - `message_history`: the continuation token or serialized transcript to reuse on the next turn
+
+   `LooperStream` stores the returned history and returns it to the caller. The user-visible output is expected to come from the interface event channel, not from the `send(...)` return value.
+
+## Contracts / invariants
+
+- `MessageHistory` is handler-family specific. A `ResponseId` only makes sense for the OpenAI Responses handler. A serialized `Messages(...)` blob only makes sense for the provider that created it.
+- Tool execution is concurrent. `LooperTools::run_tool(...)` must be safe to call from multiple tasks at the same time.
+- Tool results are JSON values, not typed Rust results. Handlers pass them back to models as serialized JSON or textified JSON depending on provider requirements.
+- Tool completion order is not guaranteed to match tool request order. Most handlers collect `JoinSet` results in completion order.
+- `SubAgentTool` assumes the child `Looper` has the same real tool capability set as the parent, minus the sub-agent tool itself. The builders document this, but the type system does not enforce it.
+- `TurnResult.final_text` is derived from the last step that has text. A tool-only turn can legitimately leave it as `None`.
+- Streaming UIs should treat `ToolCallPending` as progress, not as a fully stable contract:
+  - OpenAI Completions may emit pending events before the tool call ID is fully assembled.
+  - Gemini creates local UUIDs for tool calls because the SDK stream does not provide a stable external ID in the same shape as other providers.
+- Thinking support is provider-dependent. OpenAI Responses, Anthropic, and Gemini emit reasoning-style content. OpenAI Completions currently does not surface thinking events in this crate.
+
+## Failure modes
+
+- Configuring `.sub_agent(...)` without `.tools(...)` is a footgun. The system prompt is rendered as if sub-agent support exists, but no `SubAgentTool` is actually registered because the builders only inject it through a mutable tool registry.
+- Using `LooperStream` without `.interface_sender(...)` means the handler still writes into its internal channel, but nothing drains it. Small turns may appear to work, but large enough output can eventually fill the channel and stall progress.
+- Reusing the wrong `MessageHistory` variant with the wrong handler can fail deserialization or silently break conversation continuity.
+- Tool failures are usually surfaced to the model as JSON error payloads, not as top-level Rust errors. That keeps the loop alive, but it means the model must interpret operational failures itself.
+- Task join failures inside handlers are logged to stderr and the loop continues. This can hide partial tool execution failures from callers unless they inspect the resulting tool outputs carefully.
+- `EmptyToolSet::add_tool(...)` panics. The builders avoid calling it directly, but any future code that mutates an `EmptyToolSet` would fail hard instead of returning a recoverable error.
+
+# Related docs
+
+- [`README.md`](../README.md): public positioning, quick usage examples, and a high-level sequence diagram
+- [`examples/cli.rs`](../examples/cli.rs): a streamed UI integration with buffered output and a custom tool set
+- [`examples/cli_non_streaming.rs`](../examples/cli_non_streaming.rs): a minimal non-streaming integration that prints `TurnResult`
+- `src/mapping/tools/*`: provider-specific tool schema conversions
+- `src/types/*`: the shared contracts every layer depends on

--- a/docs/mapping-layer.md
+++ b/docs/mapping-layer.md
@@ -1,0 +1,196 @@
+---
+title: "Mapping Layer"
+when_to_read:
+  - "When you are adding a new provider and need to translate shared tool definitions into that provider's SDK types."
+  - "When you are trying to understand whether `src/mapping` is part of the active runtime path or leftover normalization scaffolding."
+summary: "The `mapping` module is the crate's translation boundary between internal types and provider-specific SDK types. In practice, the `tools` submodule is active runtime code used by handlers to register tools with each provider, while the `turn` submodule looks like an unfinished normalization layer because current handlers construct `TurnStep` values directly instead of using it."
+ontology_relations:
+  - relation: "depends_on"
+    target: "src/types/tool.rs"
+    note: "`LooperToolDefinition` is the common tool schema all tool mappings start from."
+  - relation: "depends_on"
+    target: "src/types/turn.rs"
+    note: "The `turn` mappings target `TurnStep`, which is the crate's normalized non-streaming step model."
+  - relation: "feeds"
+    target: "src/services/handlers"
+    note: "Handlers call these mappings when they need provider-native tool definitions."
+  - relation: "feeds"
+    target: "docs/core-agent-loop-architecture.md"
+    note: "This page fills in the translation layer used by the broader agent loop."
+---
+
+# Purpose
+
+Explain what `src/mapping` does, why it exists, and which parts of it matter to the live agent loop.
+
+Plain-English version: this is the translation layer between the crate's internal format and each AI provider's SDK format.
+
+# Scope
+
+This page covers:
+
+- `src/mapping/mod.rs`
+- `src/mapping/tools/*`
+- `src/mapping/turn/*`
+
+It focuses on how internal crate types are translated into provider SDK types, and where that translation layer is currently incomplete or unused.
+
+# Main content
+
+## What `mapping` is
+
+`src/mapping` is not the orchestration layer of the crate. It does not run the agent loop, execute tools, or manage conversation history.
+
+Its job is narrower: take a crate-owned type and convert it into a provider-owned type, or vice versa.
+
+If you want the simplest mental model, `mapping` is the translator between "our format" and "the provider's format."
+
+There are two submodules:
+
+- `mapping::tools`
+  Converts the crate's shared tool definition into the schema each provider SDK expects.
+- `mapping::turn`
+  Converts provider response objects into the crate's `TurnStep` shape.
+
+At the top level, [`src/mapping/mod.rs`](../src/mapping/mod.rs) exposes both submodules, but only re-exports `tools`.
+
+## The central internal type
+
+The whole `tools` mapping layer starts from [`LooperToolDefinition`](../src/types/tool.rs).
+
+That struct is the crate's provider-agnostic tool schema:
+
+- `name`
+- `description`
+- `parameters` as arbitrary JSON Schema-ish `serde_json::Value`
+
+This is the internal intermediate representation. Tool authors build this once, and handlers then map it into provider-native tool definitions.
+
+## Flow / behavior
+
+## `mapping::tools`: the active part
+
+This is the mapping code that is clearly on the runtime path today.
+
+This is the part that most directly means "translate us to the provider." The crate defines tools in one internal format, and `mapping::tools` converts them into the exact schema OpenAI, Anthropic, or Gemini expects.
+
+The flow looks like this:
+
+1. A tool implementation exposes `LooperToolDefinition`.
+2. A handler receives `Vec<LooperToolDefinition>` through `set_tools(...)`.
+3. The handler converts those definitions into the SDK type its provider expects.
+4. The provider SDK request is built using those converted tool definitions.
+
+### OpenAI Completions
+
+[`src/mapping/tools/openai_completions.rs`](../src/mapping/tools/openai_completions.rs) implements:
+
+- `From<LooperToolDefinition> for ChatCompletionTool`
+
+That is why the handler can write:
+
+- `ChatCompletionTools::Function(t.into())`
+
+in [`src/services/handlers/openai_completions.rs`](../src/services/handlers/openai_completions.rs).
+
+This mapping is thin. It passes through the internal name, description, and parameter schema into OpenAI's chat-completions tool type.
+
+### OpenAI Responses
+
+[`src/mapping/tools/openai_responses.rs`](../src/mapping/tools/openai_responses.rs) implements:
+
+- `From<LooperToolDefinition> for FunctionTool`
+
+This supports the same pattern in the Responses handler:
+
+- `Tool::Function(t.into())`
+
+in [`src/services/handlers/openai_responses.rs`](../src/services/handlers/openai_responses.rs).
+
+Conceptually this is the same as the completions mapping, just against a different OpenAI SDK surface.
+
+### Anthropic
+
+[`src/mapping/tools/anthropic.rs`](../src/mapping/tools/anthropic.rs) implements:
+
+- `From<LooperToolDefinition> for async_anthropic::types::Tool`
+
+The Anthropic handler uses that via plain `.into()` in [`src/services/handlers/anthropic.rs`](../src/services/handlers/anthropic.rs).
+
+Anthropic's shape is simple here: the internal tool name becomes the external name, the description is optional, and `parameters` becomes `input_schema`.
+
+### Gemini
+
+Gemini is the one exception to the trait-based pattern.
+
+[`src/mapping/tools/gemini.rs`](../src/mapping/tools/gemini.rs) exposes a function:
+
+- `to_gemini_tool(Vec<LooperToolDefinition>) -> Tool`
+
+instead of a `From<LooperToolDefinition>` impl.
+
+The reason is in the code comment: the SDK's `FunctionDeclaration` does not expose the needed parameter fields publicly, so the crate constructs the Gemini schema through `serde_json::from_value(...)` instead.
+
+The Gemini handlers call it directly in [`src/services/handlers/gemini.rs`](../src/services/handlers/gemini.rs) and the non-streaming variant.
+
+This is the most "adapter-like" part of the mapping layer because it has to work around an SDK API limitation instead of just renaming fields.
+
+## `mapping::turn`: a normalization layer that is not on the main path
+
+The `turn` submodule contains provider-to-`TurnStep` conversions:
+
+- [`src/mapping/turn/openai_completions.rs`](../src/mapping/turn/openai_completions.rs)
+- [`src/mapping/turn/anthropic.rs`](../src/mapping/turn/anthropic.rs)
+- [`src/mapping/turn/gemini.rs`](../src/mapping/turn/gemini.rs)
+
+Each file implements `From<ProviderResponse> for TurnStep`.
+
+The intent is straightforward:
+
+- extract thinking blocks
+- extract assistant text
+- ignore tool calls here because handlers need to execute them and attach results
+
+That design makes sense in theory, but there is an important practical detail: current non-streaming handlers do not call these conversions. They build `TurnStep` directly inside the handlers while they are also collecting tool call records.
+
+So today, `mapping::turn` reads more like a partial abstraction that was started but never fully adopted.
+
+That means the most accurate short description today is:
+
+- active path: us -> provider, mainly for tool definitions
+- partial path: provider -> us, for turn normalization, but not the main runtime path
+
+## Why this split exists
+
+The split between `tools` and `turn` reflects two different normalization problems:
+
+- outbound normalization:
+  turn one crate-owned tool definition into four different SDK shapes
+- inbound normalization:
+  turn different provider responses into one crate-owned `TurnStep`
+
+Outbound normalization is complete enough to be useful, so it is active.
+Inbound normalization is harder because tool execution is interleaved with response parsing, so the handlers currently own most of that logic themselves.
+
+## Contracts / invariants
+
+- `mapping::tools` assumes `LooperToolDefinition.parameters` is already valid enough for the target provider to accept.
+- The OpenAI and Anthropic mappings are intentionally thin adapters. They mostly rename or reposition fields.
+- The Gemini mapping is not field-by-field construction through normal SDK builders; it relies on serde to populate a type whose relevant fields are not public.
+- `mapping::turn` only models text and thinking extraction. It does not model executed tool results, which is one reason handlers still need custom logic.
+- The `From` impl pattern is used so handlers can stay terse and provider code can do `t.into()` instead of knowing every schema detail.
+
+## Failure modes
+
+- If a tool definition contains a schema the provider SDK rejects, the failure happens when the request builder or provider API consumes the mapped type, not earlier in `LooperToolDefinition`.
+- Several mappings use `expect(...)` during construction. That means bad assumptions about SDK builders or schema shape can panic instead of returning a normal error.
+- Gemini is the most brittle mapping because it depends on serde shape compatibility with an external SDK type rather than normal public field setters.
+- `mapping::turn` can drift from real runtime behavior because it is not the code path that currently constructs `TurnStep` during actual non-streaming execution.
+- The OpenAI Completions turn mapper has a visible sign of that drift: it computes `has_tool_calls` but returns `Vec::new()` in both branches, which means the conditional currently carries no behavior.
+
+# Related docs
+
+- [`docs/core-agent-loop-architecture.md`](./core-agent-loop-architecture.md): explains where the mapping layer sits inside the larger agent loop
+- [`src/types/tool.rs`](../src/types/tool.rs): the shared tool schema all outbound mappings depend on
+- [`src/types/turn.rs`](../src/types/turn.rs): the normalized non-streaming turn model the inbound mappings target
+- [`src/services/handlers`](../src/services/handlers): the main consumers of the tool mappings

--- a/docs/services-layer.md
+++ b/docs/services-layer.md
@@ -1,0 +1,210 @@
+---
+title: "Services Layer"
+when_to_read:
+  - "When you are adding or changing a provider handler and need to understand the runtime contract `Looper` depends on."
+  - "When you are debugging how a turn becomes provider requests, tool execution, streamed events, and updated message history."
+summary: "The `services` module is the provider execution layer of the crate. `Looper` and `LooperStream` select a handler from this module, then the handler owns the real work: restore history, send the request, parse text and reasoning, execute tools, recurse until no more tool calls remain, and return either a `TurnResult` or updated `MessageHistory`."
+ontology_relations:
+  - relation: "depends_on"
+    target: "src/types"
+    note: "The handler contracts depend on shared types like `MessageHistory`, `TurnResult`, and tool definitions."
+  - relation: "depends_on"
+    target: "src/tools/mod.rs"
+    note: "Handlers execute tool calls through `LooperTools`."
+  - relation: "depends_on"
+    target: "src/mapping/tools"
+    note: "Some handlers use tool mappings to convert internal tool definitions into provider SDK types."
+  - relation: "feeds"
+    target: "src/looper.rs"
+    note: "`Looper` delegates non-streaming turn execution to this layer."
+  - relation: "feeds"
+    target: "src/looper_stream.rs"
+    note: "`LooperStream` delegates streaming turn execution to this layer."
+---
+
+# Purpose
+
+Explain what `src/services` does and why it is the main runtime layer of the crate.
+
+Plain-English version: if `Looper` is the shell, `services` is the part that actually talks to the model providers and runs the agent loop.
+
+# Scope
+
+This page covers:
+
+- `src/services/mod.rs`
+- `src/services/chat_handler.rs`
+- `src/services/chat_handler_streaming.rs`
+- `src/services/handlers/*`
+
+It focuses on the contract the rest of the crate relies on and the common execution pattern shared across provider handlers.
+
+# Main content
+
+## What `services` is
+
+`services` is the provider driver layer.
+
+It is the code that knows how to:
+
+- talk to OpenAI, Anthropic, or Gemini
+- restore provider-specific conversation history
+- register provider-native tool definitions
+- parse model output into text, reasoning, and tool calls
+- run tools through the shared `LooperTools` interface
+- keep looping until the provider stops asking for tools
+
+This is where most of the real agent behavior lives.
+
+## Structure
+
+There are three parts:
+
+- [`src/services/chat_handler.rs`](../src/services/chat_handler.rs)
+  Defines the non-streaming trait `ChatHandler`.
+- [`src/services/chat_handler_streaming.rs`](../src/services/chat_handler_streaming.rs)
+  Defines the streaming trait `StreamingChatHandler`.
+- [`src/services/handlers/mod.rs`](../src/services/handlers/mod.rs)
+  Exposes one concrete handler per provider and mode.
+
+The concrete handlers are:
+
+- OpenAI Completions streaming and non-streaming
+- OpenAI Responses streaming and non-streaming
+- Anthropic streaming and non-streaming
+- Gemini streaming and non-streaming
+
+## The core contracts
+
+### Non-streaming
+
+[`ChatHandler`](../src/services/chat_handler.rs) defines:
+
+- `send_message(...) -> Result<TurnResult>`
+- `set_tools(Vec<LooperToolDefinition>)`
+
+This contract means the handler must finish the whole agent loop before returning. It is responsible for constructing the final `TurnResult`, including intermediate `TurnStep` values and the next `MessageHistory`.
+
+### Streaming
+
+[`StreamingChatHandler`](../src/services/chat_handler_streaming.rs) defines:
+
+- `send_message(...) -> Result<MessageHistory>`
+- `set_tools(Vec<LooperToolDefinition>)`
+
+This contract means the handler sends progress out incrementally and only returns the new conversation continuation state. The visible output is emitted through `HandlerToLooperMessage` events and then forwarded by `LooperStream`.
+
+## Flow / behavior
+
+Even though the provider SDK code differs, the handlers mostly follow the same loop shape.
+
+1. Restore history
+
+   The handler accepts an optional `MessageHistory` and restores provider-specific state before adding the new user message.
+
+   There are two history models:
+
+   - `MessageHistory::Messages`
+     used by OpenAI Completions, Anthropic, and Gemini
+   - `MessageHistory::ResponseId`
+     used by OpenAI Responses
+
+2. Build the provider request
+
+   The handler takes:
+
+   - the current provider-specific history
+   - the user message or recursive tool-result input
+   - the currently registered tool definitions
+   - provider-specific options like thinking or reasoning configuration
+
+   and turns that into one provider API request.
+
+3. Parse the provider response
+
+   The handler extracts some combination of:
+
+   - assistant text
+   - reasoning or thinking content
+   - tool call requests
+
+   In non-streaming mode, this gets accumulated into a `TurnStep`.
+   In streaming mode, this gets emitted as `HandlerToLooperMessage` values while the response is arriving.
+
+4. Execute tools concurrently
+
+   When tool calls are present, handlers run them through `Arc<dyn LooperTools>` using `tokio::task::JoinSet`.
+
+   This is the agentic part of the services layer:
+
+   - the model asks for tool calls
+   - the handler executes them
+   - the handler converts results into provider-native tool-result messages
+   - the handler calls itself again
+
+5. Recurse until done
+
+   Most handlers use an `inner_send_message(...)` helper marked with `#[async_recursion]`.
+
+   That helper keeps calling itself until the provider returns a response with no more tool calls. At that point:
+
+   - non-streaming handlers finalize `TurnResult`
+   - streaming handlers emit `TurnComplete` and return updated `MessageHistory`
+
+## A concrete example
+
+[`OpenAIResponsesNonStreamingHandler`](../src/services/handlers/openai_responses_non_streaming.rs) shows the pattern clearly:
+
+- it restores `previous_response_id`
+- builds a Responses API request
+- extracts reasoning, text, and function calls from `response.output`
+- runs function calls concurrently
+- pushes `FunctionCallOutput` items back into the next recursive request
+- appends a `TurnStep` for each provider round-trip
+
+Anthropic and Gemini do the same job with different SDK shapes:
+
+- Anthropic stores full assistant content blocks, then appends `ToolResult` user messages
+- Gemini stores `Part` lists and appends `FunctionResponse` parts
+
+## What changes across providers
+
+The high-level loop is stable, but the provider mechanics are not.
+
+- OpenAI Responses is the most server-state-oriented handler.
+  It continues the conversation through `previous_response_id` instead of a locally stored message vector.
+- OpenAI Completions stores a full local message list and appends assistant and tool messages directly.
+- Anthropic models thinking, text, and tool-use as content blocks inside assistant messages.
+- Gemini models text and tool calls as `Part` values and needs a small mapping helper to build tool schemas.
+
+So `services` is not one abstract engine with tiny provider plugins. It is a shared control pattern implemented separately for each provider family.
+
+## Contracts / invariants
+
+- A handler must accept shared tool definitions through `set_tools(...)`, but it is free to store them in any provider-native shape internally.
+- The `tools_runner` argument is the execution boundary. Handlers do not know how tools work; they only invoke `run_tool(...)`.
+- The services layer owns provider-specific history restoration. `Looper` only stores and passes `MessageHistory`; it does not interpret it.
+- Non-streaming handlers must reconstruct `TurnStep` and `TurnResult` themselves. This is why much of the runtime logic lives here rather than in `mapping::turn`.
+- Streaming handlers must emit events in a sequence the UI can interpret:
+  - assistant text deltas
+  - optional thinking content
+  - tool progress and completion
+  - final turn completion
+- Tool calls are executed concurrently, so result order can differ from request order.
+
+## Failure modes
+
+- Passing the wrong `MessageHistory` variant to a handler can break deserialization or conversation continuity.
+- Several handlers swallow provider stream errors by printing them instead of returning them immediately. That can make failures look like partial or odd output instead of a hard error.
+- Tool execution join errors are logged and the loop continues, which means some tool failures can be degraded into incomplete model context rather than surfaced as a top-level failure.
+- Provider setup failures happen here, not in `Looper`:
+  - missing Gemini API environment variables fail during handler construction
+  - provider request-building errors fail inside the handler before or during the API call
+- Because recursion is owned by the handlers, any bug in provider-specific tool-result encoding can trap a turn in a broken follow-up cycle or cause the model to lose context after a tool call.
+
+# Related docs
+
+- [`docs/core-agent-loop-architecture.md`](./core-agent-loop-architecture.md): broader architecture across `Looper`, handlers, tools, and history
+- [`docs/mapping-layer.md`](./mapping-layer.md): the translation layer some handlers rely on for provider-native tool schemas
+- [`src/looper.rs`](../src/looper.rs): the non-streaming entry point that selects a `ChatHandler`
+- [`src/looper_stream.rs`](../src/looper_stream.rs): the streaming entry point that selects a `StreamingChatHandler`

--- a/docs/tools-layer.md
+++ b/docs/tools-layer.md
@@ -1,0 +1,227 @@
+---
+title: "Tools Layer"
+when_to_read:
+  - "When you are implementing a new tool or tool registry and need to understand what the handlers expect."
+  - "When you are debugging tool execution, sub-agent injection, or why a model sees a tool but cannot use it correctly."
+summary: "The `tools` module is the capability boundary between the model-facing agent loop and your application logic. A `LooperTool` describes and executes one tool, while a `LooperTools` implementation is the registry and dispatcher that exposes tools to handlers, runs them by name, and optionally accepts injected capabilities like the built-in sub-agent tool."
+ontology_relations:
+  - relation: "depends_on"
+    target: "src/types/tool.rs"
+    note: "The tools layer uses `LooperToolDefinition` as the provider-agnostic schema for advertising tools."
+  - relation: "feeds"
+    target: "src/services"
+    note: "Handlers call `LooperTools::get_tools` and `LooperTools::run_tool` to register and execute model-requested tools."
+  - relation: "feeds"
+    target: "src/mapping/tools"
+    note: "Tool definitions from this layer are translated into provider-native tool schemas there."
+  - relation: "feeds"
+    target: "docs/core-agent-loop-architecture.md"
+    note: "This page explains the capability system used by the broader agent loop."
+---
+
+# Purpose
+
+Explain what `src/tools` does and how it fits into the runtime.
+
+Plain-English version: this is the layer where the model's requested actions become your app's real code.
+
+# Scope
+
+This page covers:
+
+- `src/tools/mod.rs`
+- `src/tools/empty.rs`
+- `src/tools/sub_agent.rs`
+- the example `ToolSet` implementations in `examples/cli.rs` and `examples/cli_non_streaming.rs`
+
+It focuses on the tool contract, the registry contract, and the built-in behavior this crate provides out of the box.
+
+# Main content
+
+## What `tools` is
+
+The `tools` layer is the capability boundary of the crate.
+
+It answers two different questions:
+
+- what tools exist and how should they be described to the model?
+- when the model asks for a tool by name, how do we actually run it?
+
+That is why the module has two traits instead of one.
+
+## Structure
+
+[`src/tools/mod.rs`](../src/tools/mod.rs) defines:
+
+- `LooperTool`
+  one executable tool
+- `LooperTools`
+  a tool registry plus dispatcher
+
+The built-ins are:
+
+- [`EmptyToolSet`](../src/tools/empty.rs)
+  a no-tools fallback
+- [`SubAgentTool`](../src/tools/sub_agent.rs)
+  a special tool that wraps another `Looper`
+
+## The two levels of abstraction
+
+### `LooperTool`: one tool
+
+[`LooperTool`](../src/tools/mod.rs) has three responsibilities:
+
+- `tool() -> LooperToolDefinition`
+  returns the schema the model sees
+- `get_tool_name() -> String`
+  returns the dispatch key used by the registry
+- `execute(&mut self, args: &Value) -> Value`
+  performs the real work and returns a JSON result
+
+This means a single tool has both:
+
+- a declarative side
+  name, description, parameters
+- an operational side
+  actual execution against runtime input
+
+The args and result are both `serde_json::Value`, so the tool boundary is intentionally dynamic rather than strongly typed.
+
+### `LooperTools`: the registry
+
+[`LooperTools`](../src/tools/mod.rs) is the surface the rest of the runtime calls.
+
+It has three responsibilities:
+
+- `get_tools()`
+  enumerate tool definitions for provider registration
+- `add_tool(...)`
+  mutate the registry by adding a tool
+- `run_tool(name, args)`
+  dispatch a model-requested tool call by name
+
+Plain-English version:
+
+- `LooperTool` is one tool
+- `LooperTools` is the toolbox
+
+## Flow / behavior
+
+1. Tool authoring
+
+   A tool implementation returns a [`LooperToolDefinition`](../src/types/tool.rs) from `tool()`.
+
+   That definition includes:
+
+   - name
+   - description
+   - parameter schema
+
+2. Registry exposure
+
+   A `LooperTools` implementation collects all tool definitions and returns them from `get_tools()`.
+
+   This is what `Looper` and `LooperStream` pass into handlers during build.
+
+3. Provider registration
+
+   The handlers convert those generic tool definitions into provider-native schemas through the mapping layer.
+
+4. Runtime execution
+
+   When a provider response contains a tool call, the handler invokes:
+
+   - `run_tool(name, args)`
+
+   on the registry.
+
+   The registry finds the matching `LooperTool` and calls `execute(...)`.
+
+5. Result return
+
+   The JSON result goes back to the handler, which packages it into the provider-specific tool-result message format and continues the loop.
+
+So the tools layer is where the abstract model request becomes concrete application behavior.
+
+## The example registry pattern
+
+The example CLIs show the intended usage pattern well.
+
+In [`examples/cli_non_streaming.rs`](../examples/cli_non_streaming.rs) and [`examples/cli.rs`](../examples/cli.rs), the registry:
+
+- stores tools in a `HashMap<String, Mutex<Arc<dyn LooperTool>>>`
+- exposes schemas by iterating over tools and calling `tool()`
+- dispatches by tool name in `run_tool(...)`
+
+This reveals an important design choice in the crate:
+
+- the library defines the tool contract
+- the caller owns the actual registry implementation
+
+There is no full built-in mutable tool registry in `src/tools`; you are expected to provide one.
+
+## Built-in tool implementations
+
+### `EmptyToolSet`
+
+[`EmptyToolSet`](../src/tools/empty.rs) is the default fallback when no tools are provided.
+
+Its behavior is intentional:
+
+- `get_tools()` returns an empty list
+- `run_tool(...)` returns a JSON error saying the function is unknown
+- `add_tool(...)` panics
+
+This makes it safe as a read-only "no tools available" fallback, but unsafe as a mutable registry.
+
+### `SubAgentTool`
+
+[`SubAgentTool`](../src/tools/sub_agent.rs) is a special built-in tool that wraps another non-streaming `Looper`.
+
+Its schema exposes one argument:
+
+- `task_description: string`
+
+Its execution path is:
+
+1. read `task_description`
+2. call the child `Looper`
+3. return either:
+   - `{ "agent_findings": ... }`
+   - or an error payload
+
+This lets the parent model delegate work to a child agent without knowing anything about the child implementation beyond the tool interface.
+
+## How sub-agent injection really works
+
+The builders in `Looper` and `LooperStream` can inject `SubAgentTool` automatically when `.sub_agent(...)` is configured.
+
+That only works if the caller supplied a real mutable `LooperTools` implementation. The builders inject the sub-agent by calling `add_tool(...)` on that registry before registering tool definitions with the handler.
+
+So the tools layer is not just a passive trait boundary. It is also the place where the runtime mutates available capabilities during build.
+
+## Contracts / invariants
+
+- `tool().name` and `get_tool_name()` must effectively agree. If they diverge, the model may request one name while the registry dispatches under another.
+- Tool args and results are JSON values. Validation is the tool author's job, not the framework's.
+- `run_tool(...)` must be safe under concurrent access because handlers execute tool calls in parallel.
+- A `LooperTools` implementation must be able to expose tool schemas and execute the same tools consistently by name.
+- If you want sub-agent support, your registry must support `add_tool(...)`.
+- Tools are allowed to be stateful because `execute(...)` takes `&mut self`, but the registry is responsible for making mutable access safe.
+
+## Failure modes
+
+- Unknown tool names do not usually cause a top-level Rust error. They typically come back as JSON error payloads from the registry.
+- `EmptyToolSet::add_tool(...)` panics, so it cannot be used as a mutable registry.
+- If `tool().name` and `get_tool_name()` do not match, the model-facing schema and runtime dispatch key can diverge in subtle ways.
+- A registry that is not concurrency-safe can corrupt state or deadlock when handlers run multiple tools at once.
+- The example registry pattern uses `Arc::get_mut(...)`, which assumes the registry holds the only strong reference to each tool. If that assumption stops being true, execution will panic.
+- `SubAgentTool` depends on a child `Looper` that is expected to have the same practical tool capability set as the parent, minus sub-agent recursion. That assumption is documented but not enforced by the type system.
+
+# Related docs
+
+- [`docs/services-layer.md`](./services-layer.md): explains how handlers consume tool registries and execute tool calls
+- [`docs/mapping-layer.md`](./mapping-layer.md): explains how tool definitions are translated into provider-native schemas
+- [`src/types/tool.rs`](../src/types/tool.rs): the shared tool definition type used by every tool
+- [`src/looper.rs`](../src/looper.rs): shows where builders inject `SubAgentTool` into a mutable registry
+- [`src/looper_stream.rs`](../src/looper_stream.rs): the streaming builder follows the same injection pattern


### PR DESCRIPTION
## Summary
- add AGENTS.md for contributor guidance
- add core architecture documentation under docs/

## Files
- AGENTS.md
- docs/core-agent-loop-architecture.md
- docs/mapping-layer.md
- docs/services-layer.md
- docs/tools-layer.md