### PR TITLE
refactor: Fix cargo-husky hook failures

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,15 +1,23 @@
-use std::{collections::HashMap, error::Error, io::{self, Write}, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    error::Error,
+    io::{self, Write},
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use console::{Style, Term};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde_json::{Value, json};
-use tokio::sync::{mpsc, Mutex, Notify};
+use tokio::sync::{Mutex, Notify, mpsc};
 
 use looper::{
-    looper::Looper, looper_stream::LooperStream, tools::{LooperTool, LooperTools}, types::{Handlers, LooperToInterfaceMessage, LooperToolDefinition}
+    looper::Looper,
+    looper_stream::LooperStream,
+    tools::{LooperTool, LooperTools},
+    types::{Handlers, LooperToInterfaceMessage, LooperToolDefinition},
 };
-
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -45,34 +53,36 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let turn_done = Arc::new(Notify::new());
     let turn_done_tx = turn_done.clone();
 
-    tokio::spawn(async move{
+    tokio::spawn(async move {
         let theme = Theme::default();
         let mut spinner: Option<ProgressBar> = None;
 
         while let Some(message) = rx.recv().await {
-            if let Some(sp) = spinner.take() { sp.finish_and_clear(); }
+            if let Some(sp) = spinner.take() {
+                sp.finish_and_clear();
+            }
 
             match message {
                 LooperToInterfaceMessage::Assistant(m) => {
                     print!("{}", m);
                     io::stdout().flush().ok();
-                },
+                }
                 LooperToInterfaceMessage::Thinking(m) => {
                     print!("{}", theme.thinking.apply_to(&m));
                     io::stdout().flush().ok();
-                },
+                }
                 LooperToInterfaceMessage::ThinkingComplete => {
                     println!();
-                },
+                }
                 LooperToInterfaceMessage::ToolCall(name) => {
                     spinner = Some(theme.tool_spinner(&name));
-                },
+                }
                 LooperToInterfaceMessage::ToolCallPending(_id) => {
                     // TODO: Implement intelligent swap of tool calls based on id
-                },
+                }
                 LooperToInterfaceMessage::ToolCallComplete(_id) => {
                     // TODO: Handle tool call completion
-                },
+                }
                 LooperToInterfaceMessage::TurnComplete => {
                     println!("\n{}", theme.separator_line());
                     turn_done_tx.notify_one();
@@ -93,14 +103,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-
 // ── Tool implementations ────────────────────────────────────────────
 
 struct ReadFileTool;
 
 #[async_trait]
 impl LooperTool for ReadFileTool {
-    fn get_tool_name(&self) -> String { "read_file".to_string() }
+    fn get_tool_name(&self) -> String {
+        "read_file".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -128,7 +139,9 @@ struct WriteFileTool;
 
 #[async_trait]
 impl LooperTool for WriteFileTool {
-    fn get_tool_name(&self) -> String { "write_file".to_string() }
+    fn get_tool_name(&self) -> String {
+        "write_file".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -161,7 +174,9 @@ struct ListDirectoryTool;
 
 #[async_trait]
 impl LooperTool for ListDirectoryTool {
-    fn get_tool_name(&self) -> String { "list_directory".to_string() }
+    fn get_tool_name(&self) -> String {
+        "list_directory".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -183,7 +198,11 @@ impl LooperTool for ListDirectoryTool {
                 let mut items = Vec::new();
                 while let Ok(Some(entry)) = entries.next_entry().await {
                     let name = entry.file_name().to_string_lossy().to_string();
-                    let is_dir = entry.file_type().await.map(|ft| ft.is_dir()).unwrap_or(false);
+                    let is_dir = entry
+                        .file_type()
+                        .await
+                        .map(|ft| ft.is_dir())
+                        .unwrap_or(false);
                     if is_dir {
                         items.push(format!("{}/", name));
                     } else {
@@ -202,7 +221,9 @@ struct GrepTool;
 
 #[async_trait]
 impl LooperTool for GrepTool {
-    fn get_tool_name(&self) -> String { "grep".to_string() }
+    fn get_tool_name(&self) -> String {
+        "grep".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -246,7 +267,9 @@ struct FindFilesTool;
 
 #[async_trait]
 impl LooperTool for FindFilesTool {
-    fn get_tool_name(&self) -> String { "find_files".to_string() }
+    fn get_tool_name(&self) -> String {
+        "find_files".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -290,10 +313,19 @@ impl ToolSet {
     fn new() -> Self {
         let mut tools: HashMap<String, Mutex<Arc<dyn LooperTool>>> = HashMap::new();
         tools.insert("read_file".to_string(), Mutex::new(Arc::new(ReadFileTool)));
-        tools.insert("write_file".to_string(), Mutex::new(Arc::new(WriteFileTool)));
-        tools.insert("list_directory".to_string(), Mutex::new(Arc::new(ListDirectoryTool)));
+        tools.insert(
+            "write_file".to_string(),
+            Mutex::new(Arc::new(WriteFileTool)),
+        );
+        tools.insert(
+            "list_directory".to_string(),
+            Mutex::new(Arc::new(ListDirectoryTool)),
+        );
         tools.insert("grep".to_string(), Mutex::new(Arc::new(GrepTool)));
-        tools.insert("find_files".to_string(), Mutex::new(Arc::new(FindFilesTool)));
+        tools.insert(
+            "find_files".to_string(),
+            Mutex::new(Arc::new(FindFilesTool)),
+        );
         ToolSet { tools }
     }
 }
@@ -322,13 +354,11 @@ impl LooperTools for ToolSet {
                 let mut arc = tool_mutex.lock().await;
                 let tool = Arc::get_mut(&mut arc).expect("tool has multiple references");
                 tool.execute(&args).await
-            },
+            }
             None => json!({"error": format!("Unknown function: {}", name)}),
         }
     }
 }
-
-
 
 // ── CLI STYLING ────────────────────────────────────────────────────────
 struct Theme {
@@ -356,14 +386,15 @@ impl Theme {
     }
 
     fn separator_line(&self) -> String {
-        self.separator.apply_to("────────────────────────────────").to_string()
+        self.separator
+            .apply_to("────────────────────────────────")
+            .to_string()
     }
 
     fn tool_spinner(&self, name: &str) -> ProgressBar {
         let sp = ProgressBar::new_spinner();
         sp.set_style(
-            ProgressStyle::default_spinner()
-                .tick_strings(&["▖", "▘", "▝", "▗", "▚", "▞", ""])
+            ProgressStyle::default_spinner().tick_strings(&["▖", "▘", "▝", "▗", "▚", "▞", ""]),
         );
         sp.set_message(self.tool_spinner.apply_to(name).to_string());
         sp.enable_steady_tick(Duration::from_millis(80));

--- a/examples/cli_non_streaming.rs
+++ b/examples/cli_non_streaming.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, error::Error, io::{self, Write}, sync::Arc};
+use std::{
+    collections::HashMap,
+    error::Error,
+    io::{self, Write},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -9,7 +14,6 @@ use looper::{
     types::{Handlers, LooperToolDefinition},
 };
 use tokio::sync::Mutex;
-
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -28,7 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .sub_agent(agent_looper)
         .instructions("You're being used as a CLI example for an agent loop. Be succinct yet friendly and helpful.")
         .build().await?;
-
 
     loop {
         print!("> ");
@@ -64,14 +67,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-
 // ── Tool implementations ────────────────────────────────────────────
 
 struct ReadFileTool;
 
 #[async_trait]
 impl LooperTool for ReadFileTool {
-    fn get_tool_name(&self) -> String { "read_file".to_string() }
+    fn get_tool_name(&self) -> String {
+        "read_file".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -99,7 +103,9 @@ struct ListDirectoryTool;
 
 #[async_trait]
 impl LooperTool for ListDirectoryTool {
-    fn get_tool_name(&self) -> String { "list_directory".to_string() }
+    fn get_tool_name(&self) -> String {
+        "list_directory".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -121,7 +127,11 @@ impl LooperTool for ListDirectoryTool {
                 let mut items = Vec::new();
                 while let Ok(Some(entry)) = entries.next_entry().await {
                     let name = entry.file_name().to_string_lossy().to_string();
-                    let is_dir = entry.file_type().await.map(|ft| ft.is_dir()).unwrap_or(false);
+                    let is_dir = entry
+                        .file_type()
+                        .await
+                        .map(|ft| ft.is_dir())
+                        .unwrap_or(false);
                     if is_dir {
                         items.push(format!("{}/", name));
                     } else {
@@ -146,7 +156,10 @@ impl ToolSet {
     fn new() -> Self {
         let mut tools: HashMap<String, Mutex<Arc<dyn LooperTool>>> = HashMap::new();
         tools.insert("read_file".to_string(), Mutex::new(Arc::new(ReadFileTool)));
-        tools.insert("list_directory".to_string(), Mutex::new(Arc::new(ListDirectoryTool)));
+        tools.insert(
+            "list_directory".to_string(),
+            Mutex::new(Arc::new(ListDirectoryTool)),
+        );
         ToolSet { tools }
     }
 }
@@ -175,7 +188,7 @@ impl LooperTools for ToolSet {
                 let mut arc = tool_mutex.lock().await;
                 let tool = Arc::get_mut(&mut arc).expect("tool has multiple references");
                 tool.execute(&args).await
-            },
+            }
             None => json!({"error": format!("Unknown function: {}", name)}),
         }
     }

--- a/src/looper.rs
+++ b/src/looper.rs
@@ -1,23 +1,20 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use tera::{Tera, Context};
+use tera::{Context, Tera};
 
 use crate::{
     services::{
-        ChatHandler, handlers::{
+        ChatHandler,
+        handlers::{
             anthropic_non_streaming::AnthropicNonStreamingHandler,
             gemini_non_streaming::GeminiNonStreamingHandler,
             openai_completions_non_streaming::OpenAINonStreamingChatHandler,
-            openai_responses_non_streaming::OpenAIResponsesNonStreamingHandler
-        }
+            openai_responses_non_streaming::OpenAIResponsesNonStreamingHandler,
+        },
     },
-    tools::{
-        EmptyToolSet, LooperTools, SubAgentTool
-    },
-    types::{
-        Handlers, MessageHistory, turn::TurnResult
-    },
+    tools::{EmptyToolSet, LooperTools, SubAgentTool},
+    types::{Handlers, MessageHistory, turn::TurnResult},
 };
 
 pub struct Looper {
@@ -66,7 +63,7 @@ impl<'a> LooperBuilder<'a> {
         let handler: Box<dyn ChatHandler> = match self.handler_type {
             Handlers::Anthropic(m) => {
                 let mut handler = AnthropicNonStreamingHandler::new(
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -82,7 +79,7 @@ impl<'a> LooperBuilder<'a> {
             }
             Handlers::OpenAICompletions(m) => {
                 let mut handler = OpenAINonStreamingChatHandler::new(
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -98,7 +95,7 @@ impl<'a> LooperBuilder<'a> {
             }
             Handlers::OpenAIResponses(m) => {
                 let mut handler = OpenAIResponsesNonStreamingHandler::new(
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -114,7 +111,7 @@ impl<'a> LooperBuilder<'a> {
             }
             Handlers::Gemini(m) => {
                 let mut handler = GeminiNonStreamingHandler::new(
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -131,8 +128,16 @@ impl<'a> LooperBuilder<'a> {
         };
 
         match self.tools {
-            Some(t) => Ok(Looper { handler, message_history: self.message_history, tools: Arc::from(t) }),
-            None => Ok(Looper { handler, message_history: self.message_history, tools: Arc::new(EmptyToolSet) })
+            Some(t) => Ok(Looper {
+                handler,
+                message_history: self.message_history,
+                tools: Arc::from(t),
+            }),
+            None => Ok(Looper {
+                handler,
+                message_history: self.message_history,
+                tools: Arc::new(EmptyToolSet),
+            }),
         }
     }
 }
@@ -151,11 +156,7 @@ impl Looper {
     pub async fn send(&mut self, message: &str) -> Result<TurnResult> {
         let result = self
             .handler
-            .send_message(
-                self.message_history.clone(),
-                message,
-                self.tools.clone(),
-            )
+            .send_message(self.message_history.clone(), message, self.tools.clone())
             .await?;
 
         self.message_history = Some(result.message_history.clone());
@@ -165,9 +166,9 @@ impl Looper {
 }
 
 fn render_system_message(
-    template: &str, 
+    template: &str,
     instructions: Option<&str>,
-    sub_agent_enabled: bool
+    sub_agent_enabled: bool,
 ) -> Result<String> {
     let mut tera = Tera::default();
     tera.add_raw_template("system_prompt", template)?;
@@ -184,9 +185,10 @@ fn render_system_message(
     Ok(tera.render("system_prompt", &ctx)?)
 }
 
-fn get_system_message(
-    instructions: Option<&str>,
-    sub_agent_enabled: bool
-) -> Result<String> {
-    render_system_message(include_str!("../prompts/system_prompt.txt"), instructions, sub_agent_enabled)
+fn get_system_message(instructions: Option<&str>, sub_agent_enabled: bool) -> Result<String> {
+    render_system_message(
+        include_str!("../prompts/system_prompt.txt"),
+        instructions,
+        sub_agent_enabled,
+    )
 }

--- a/src/looper_stream.rs
+++ b/src/looper_stream.rs
@@ -5,22 +5,14 @@ use std::time::Duration;
 use crate::{
     looper::Looper,
     services::{
-        StreamingChatHandler, anthropic::AnthropicHandler,
-        gemini::GeminiHandler,
-        openai_completions::OpenAIChatHandler, openai_responses::OpenAIResponsesHandler
+        StreamingChatHandler, anthropic::AnthropicHandler, gemini::GeminiHandler,
+        openai_completions::OpenAIChatHandler, openai_responses::OpenAIResponsesHandler,
     },
-    tools::{
-        EmptyToolSet, LooperTools, SubAgentTool
-    },
-    types::{
-        HandlerToLooperMessage,
-        Handlers,
-        LooperToInterfaceMessage,
-        MessageHistory
-    }
+    tools::{EmptyToolSet, LooperTools, SubAgentTool},
+    types::{HandlerToLooperMessage, Handlers, LooperToInterfaceMessage, MessageHistory},
 };
 use anyhow::Result;
-use tera::{Tera, Context};
+use tera::{Context, Tera};
 use tokio::sync::mpsc::{self, Sender};
 
 const BUFFER_DRAIN_INTERVAL_MS: u64 = 5;
@@ -85,7 +77,7 @@ impl<'a> LooperStreamBuilder<'a> {
             Handlers::OpenAICompletions(m) => {
                 let mut handler = OpenAIChatHandler::new(
                     handler_looper_sender,
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -98,11 +90,11 @@ impl<'a> LooperStreamBuilder<'a> {
                 }
 
                 Box::new(handler)
-            },
+            }
             Handlers::OpenAIResponses(m) => {
                 let mut handler = OpenAIResponsesHandler::new(
                     handler_looper_sender,
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -115,11 +107,11 @@ impl<'a> LooperStreamBuilder<'a> {
                 }
 
                 Box::new(handler)
-            },
+            }
             Handlers::Anthropic(m) => {
                 let mut handler = AnthropicHandler::new(
                     handler_looper_sender,
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -136,7 +128,7 @@ impl<'a> LooperStreamBuilder<'a> {
             Handlers::Gemini(m) => {
                 let mut handler = GeminiHandler::new(
                     handler_looper_sender,
-                    &m,
+                    m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
 
@@ -159,7 +151,8 @@ impl<'a> LooperStreamBuilder<'a> {
             tokio::spawn(async move {
                 if buffered {
                     let mut pool: VecDeque<char> = VecDeque::new();
-                    let mut interval = tokio::time::interval(Duration::from_millis(BUFFER_DRAIN_INTERVAL_MS));
+                    let mut interval =
+                        tokio::time::interval(Duration::from_millis(BUFFER_DRAIN_INTERVAL_MS));
                     let mut channel_open = true;
                     loop {
                         tokio::select! {
@@ -191,10 +184,18 @@ impl<'a> LooperStreamBuilder<'a> {
                     while let Some(message) = handler_looper_receiver.recv().await {
                         match message {
                             HandlerToLooperMessage::Assistant(m) => {
-                                if l_i_s.send(LooperToInterfaceMessage::Assistant(m)).await.is_err() { break; }
+                                if l_i_s
+                                    .send(LooperToInterfaceMessage::Assistant(m))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
                             }
                             other => {
-                                if forward_non_text(&l_i_s, other).await.is_err() { break; }
+                                if forward_non_text(&l_i_s, other).await.is_err() {
+                                    break;
+                                }
                             }
                         }
                     }
@@ -203,8 +204,16 @@ impl<'a> LooperStreamBuilder<'a> {
         }
 
         match self.tools {
-            Some(t) => Ok(LooperStream { handler, message_history: self.message_history, tools: Arc::from(t) }),
-            None => Ok(LooperStream { handler, message_history: self.message_history, tools: Arc::new(EmptyToolSet) })
+            Some(t) => Ok(LooperStream {
+                handler,
+                message_history: self.message_history,
+                tools: Arc::from(t),
+            }),
+            None => Ok(LooperStream {
+                handler,
+                message_history: self.message_history,
+                tools: Arc::new(EmptyToolSet),
+            }),
         }
     }
 }
@@ -223,11 +232,10 @@ impl LooperStream {
     }
 
     pub async fn send(&mut self, message: &str) -> Result<MessageHistory> {
-        let history = self.handler.send_message(
-            self.message_history.clone(), 
-            message,
-            self.tools.clone()
-        ).await?;
+        let history = self
+            .handler
+            .send_message(self.message_history.clone(), message, self.tools.clone())
+            .await?;
 
         self.message_history = Some(history.clone());
 
@@ -235,22 +243,36 @@ impl LooperStream {
     }
 }
 
-async fn drain_pool(sender: &Sender<LooperToInterfaceMessage>, pool: &mut VecDeque<char>) -> Result<()> {
+async fn drain_pool(
+    sender: &Sender<LooperToInterfaceMessage>,
+    pool: &mut VecDeque<char>,
+) -> Result<()> {
     let text: String = pool.drain(..).collect();
     if !text.is_empty() {
-        sender.send(LooperToInterfaceMessage::Assistant(text)).await?;
+        sender
+            .send(LooperToInterfaceMessage::Assistant(text))
+            .await?;
     }
     Ok(())
 }
 
-async fn forward_non_text(sender: &Sender<LooperToInterfaceMessage>, msg: HandlerToLooperMessage) -> Result<()> {
+async fn forward_non_text(
+    sender: &Sender<LooperToInterfaceMessage>,
+    msg: HandlerToLooperMessage,
+) -> Result<()> {
     let interface_msg = match msg {
         HandlerToLooperMessage::Assistant(_) => unreachable!("Assistant handled separately"),
         HandlerToLooperMessage::Thinking(m) => LooperToInterfaceMessage::Thinking(m),
         HandlerToLooperMessage::ThinkingComplete => LooperToInterfaceMessage::ThinkingComplete,
-        HandlerToLooperMessage::ToolCallPending(id) => LooperToInterfaceMessage::ToolCallPending(id),
-        HandlerToLooperMessage::ToolCallRequest(tc) => LooperToInterfaceMessage::ToolCall(tc.name.clone()),
-        HandlerToLooperMessage::ToolCallComplete(id) => LooperToInterfaceMessage::ToolCallComplete(id),
+        HandlerToLooperMessage::ToolCallPending(id) => {
+            LooperToInterfaceMessage::ToolCallPending(id)
+        }
+        HandlerToLooperMessage::ToolCallRequest(tc) => {
+            LooperToInterfaceMessage::ToolCall(tc.name.clone())
+        }
+        HandlerToLooperMessage::ToolCallComplete(id) => {
+            LooperToInterfaceMessage::ToolCallComplete(id)
+        }
         HandlerToLooperMessage::TurnComplete => LooperToInterfaceMessage::TurnComplete,
     };
     sender.send(interface_msg).await?;
@@ -258,9 +280,9 @@ async fn forward_non_text(sender: &Sender<LooperToInterfaceMessage>, msg: Handle
 }
 
 fn render_system_message(
-    template: &str, 
+    template: &str,
     instructions: Option<&str>,
-    sub_agent_enabled: bool
+    sub_agent_enabled: bool,
 ) -> Result<String> {
     let mut tera = Tera::default();
     tera.add_raw_template("system_prompt", template)?;
@@ -277,9 +299,10 @@ fn render_system_message(
     Ok(tera.render("system_prompt", &ctx)?)
 }
 
-fn get_system_message(
-    instructions: Option<&str>,
-    sub_agent_enabled: bool
-) -> Result<String> {
-    render_system_message(include_str!("../prompts/system_prompt.txt"), instructions, sub_agent_enabled)
+fn get_system_message(instructions: Option<&str>, sub_agent_enabled: bool) -> Result<String> {
+    render_system_message(
+        include_str!("../prompts/system_prompt.txt"),
+        instructions,
+        sub_agent_enabled,
+    )
 }

--- a/src/mapping/tools/anthropic.rs
+++ b/src/mapping/tools/anthropic.rs
@@ -1,5 +1,5 @@
-use async_anthropic::types::Tool;
 use crate::types::LooperToolDefinition;
+use async_anthropic::types::Tool;
 
 impl From<LooperToolDefinition> for Tool {
     fn from(value: LooperToolDefinition) -> Self {

--- a/src/mapping/tools/openai_completions.rs
+++ b/src/mapping/tools/openai_completions.rs
@@ -1,5 +1,5 @@
-use async_openai::types::chat::{ChatCompletionTool, FunctionObjectArgs};
 use crate::types::LooperToolDefinition;
+use async_openai::types::chat::{ChatCompletionTool, FunctionObjectArgs};
 
 impl From<LooperToolDefinition> for ChatCompletionTool {
     fn from(value: LooperToolDefinition) -> Self {
@@ -9,7 +9,7 @@ impl From<LooperToolDefinition> for ChatCompletionTool {
                 .description(value.description)
                 .parameters(value.parameters)
                 .build()
-                .expect("Failed to build FunctionObjectArgs from LooperTool")
+                .expect("Failed to build FunctionObjectArgs from LooperTool"),
         }
     }
 }

--- a/src/mapping/tools/openai_responses.rs
+++ b/src/mapping/tools/openai_responses.rs
@@ -1,5 +1,5 @@
-use async_openai::types::responses::{FunctionTool, FunctionToolArgs};
 use crate::types::LooperToolDefinition;
+use async_openai::types::responses::{FunctionTool, FunctionToolArgs};
 
 impl From<LooperToolDefinition> for FunctionTool {
     fn from(value: LooperToolDefinition) -> Self {

--- a/src/mapping/turn/anthropic.rs
+++ b/src/mapping/turn/anthropic.rs
@@ -1,5 +1,5 @@
-use async_anthropic::types::{CreateMessagesResponse, MessageContent};
 use crate::types::turn::{ThinkingBlock, TurnStep};
+use async_anthropic::types::{CreateMessagesResponse, MessageContent};
 
 impl From<CreateMessagesResponse> for TurnStep {
     fn from(response: CreateMessagesResponse) -> Self {

--- a/src/mapping/turn/gemini.rs
+++ b/src/mapping/turn/gemini.rs
@@ -1,5 +1,5 @@
-use gemini_rust::GenerationResponse;
 use crate::types::turn::{ThinkingBlock, TurnStep};
+use gemini_rust::GenerationResponse;
 
 impl From<GenerationResponse> for TurnStep {
     fn from(response: GenerationResponse) -> Self {
@@ -10,21 +10,15 @@ impl From<GenerationResponse> for TurnStep {
         for candidate in &response.candidates {
             if let Some(parts) = &candidate.content.parts {
                 for part in parts {
-                    match part {
-                        gemini_rust::Part::Text {
-                            text: t,
-                            thought,
-                            ..
-                        } => {
-                            if *thought == Some(true) {
-                                thinking.push(ThinkingBlock {
-                                    content: t.clone(),
-                                });
-                            } else {
-                                text = Some(t.clone());
-                            }
+                    if let gemini_rust::Part::Text {
+                        text: t, thought, ..
+                    } = part
+                    {
+                        if *thought == Some(true) {
+                            thinking.push(ThinkingBlock { content: t.clone() });
+                        } else {
+                            text = Some(t.clone());
                         }
-                        _ => {}
                     }
                 }
             }

--- a/src/mapping/turn/openai_completions.rs
+++ b/src/mapping/turn/openai_completions.rs
@@ -1,17 +1,16 @@
-use async_openai::types::chat::{ChatChoice, FinishReason};
 use crate::types::turn::TurnStep;
+use async_openai::types::chat::ChatChoice;
 
 impl From<ChatChoice> for TurnStep {
     fn from(choice: ChatChoice) -> Self {
         let text = choice.message.content;
-        let has_tool_calls = matches!(choice.finish_reason, Some(FinishReason::ToolCalls));
 
         TurnStep {
             thinking: Vec::new(),
             text,
             // Tool calls are handled separately in the handler
             // since they need to be executed and recorded with results
-            tool_calls: if has_tool_calls { Vec::new() } else { Vec::new() },
+            tool_calls: Vec::new(),
         }
     }
 }

--- a/src/services/chat_handler_streaming.rs
+++ b/src/services/chat_handler_streaming.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
+use crate::{
+    tools::LooperTools,
+    types::{LooperToolDefinition, MessageHistory},
+};
 use anyhow::Result;
 use async_trait::async_trait;
-use crate::{tools::LooperTools, types::{LooperToolDefinition, MessageHistory}};
 
 #[async_trait]
 pub trait StreamingChatHandler: Send + Sync {

--- a/src/services/handlers/anthropic.rs
+++ b/src/services/handlers/anthropic.rs
@@ -3,10 +3,9 @@ use std::{collections::HashMap, sync::Arc};
 use async_anthropic::{
     Client,
     types::{
-        ContentBlockDelta, CreateMessagesRequestBuilder, Message, 
-        MessageContent, MessageContentList, MessageRole, MessagesStreamEvent, 
-        Thinking, Tool, ToolResultBuilder
-    }
+        ContentBlockDelta, CreateMessagesRequestBuilder, Message, MessageContent,
+        MessageContentList, MessageRole, MessagesStreamEvent, Thinking, Tool, ToolResultBuilder,
+    },
 };
 
 use async_recursion::async_recursion;
@@ -17,10 +16,14 @@ use futures::StreamExt;
 
 use tokio::{sync::mpsc::Sender, task::JoinSet};
 
-
-use crate::{services::StreamingChatHandler, tools::LooperTools, types::{
-    HandlerToLooperMessage, HandlerToLooperToolCallRequest, LooperToolDefinition, MessageHistory,
-}};
+use crate::{
+    services::StreamingChatHandler,
+    tools::LooperTools,
+    types::{
+        HandlerToLooperMessage, HandlerToLooperToolCallRequest, LooperToolDefinition,
+        MessageHistory,
+    },
+};
 
 pub struct AnthropicHandler {
     client: Client,
@@ -48,15 +51,12 @@ impl AnthropicHandler {
             system_message: system_message.to_string(),
             messages,
             sender,
-            tools
+            tools,
         })
     }
 
     #[async_recursion]
-    async fn inner_send_message(
-        &mut self,
-        tools_runner: Arc<dyn LooperTools>,
-    ) -> Result<String> {
+    async fn inner_send_message(&mut self, tools_runner: Arc<dyn LooperTools>) -> Result<String> {
         let request = CreateMessagesRequestBuilder::default()
             .model(&self.model)
             .system(self.system_message.clone())
@@ -65,7 +65,6 @@ impl AnthropicHandler {
             .max_tokens(16384)
             .thinking(Thinking::Adaptive)
             .build()?;
-
 
         let mut stream = self.client.messages().create_stream(request).await;
         let mut tool_join_set = JoinSet::new();
@@ -77,9 +76,12 @@ impl AnthropicHandler {
             match result {
                 Ok(response) => {
                     match response {
-                        MessagesStreamEvent::ContentBlockStart { index, content_block } => {
+                        MessagesStreamEvent::ContentBlockStart {
+                            index,
+                            content_block,
+                        } => {
                             content_blocks.insert(index, content_block);
-                        },
+                        }
                         MessagesStreamEvent::ContentBlockDelta { index, delta } => {
                             if let Some(cb) = content_blocks.get_mut(&index) {
                                 match delta {
@@ -91,7 +93,7 @@ impl AnthropicHandler {
                                                 .send(HandlerToLooperMessage::Assistant(text))
                                                 .await?;
                                         }
-                                    },
+                                    }
                                     ContentBlockDelta::ThinkingDelta { thinking } => {
                                         if let MessageContent::Thinking(t) = cb {
                                             t.thinking += &thinking;
@@ -100,7 +102,7 @@ impl AnthropicHandler {
                                                 .send(HandlerToLooperMessage::Thinking(thinking))
                                                 .await?;
                                         }
-                                    },
+                                    }
                                     ContentBlockDelta::SignatureDelta { signature } => {
                                         if let MessageContent::Thinking(_) = cb {
                                             signatures
@@ -108,7 +110,7 @@ impl AnthropicHandler {
                                                 .or_default()
                                                 .push_str(&signature);
                                         }
-                                    },
+                                    }
                                     ContentBlockDelta::InputJsonDelta { partial_json } => {
                                         if let MessageContent::ToolUse(t) = cb {
                                             tool_input_bufs
@@ -117,13 +119,15 @@ impl AnthropicHandler {
                                                 .push_str(&partial_json);
 
                                             self.sender
-                                                .send(HandlerToLooperMessage::ToolCallPending(t.id.clone()))
+                                                .send(HandlerToLooperMessage::ToolCallPending(
+                                                    t.id.clone(),
+                                                ))
                                                 .await?;
                                         }
                                     }
                                 }
                             }
-                        },
+                        }
                         MessagesStreamEvent::ContentBlockStop { index } => {
                             // Send ThinkingComplete when a thinking block ends
                             if let Some(MessageContent::Thinking(_)) = content_blocks.get(&index) {
@@ -133,17 +137,16 @@ impl AnthropicHandler {
                             }
 
                             // Parse accumulated tool input JSON if present
-                            if let Some(raw_input) = tool_input_bufs.remove(&index) {
-                                if let Some(MessageContent::ToolUse(t)) = content_blocks.get_mut(&index) {
-                                    if !raw_input.is_empty() {
-                                        t.input = serde_json::from_str(&raw_input)?;
-                                    }
-                                }
+                            if let Some(raw_input) = tool_input_bufs.remove(&index)
+                                && let Some(MessageContent::ToolUse(t)) =
+                                    content_blocks.get_mut(&index)
+                                && !raw_input.is_empty()
+                            {
+                                t.input = serde_json::from_str(&raw_input)?;
                             }
-                        },
-                        _ => ()
+                        }
+                        _ => (),
                     }
-
                 }
                 Err(err) => {
                     println!("error: {err:?}");
@@ -159,10 +162,10 @@ impl AnthropicHandler {
         for index in &sorted_indices {
             if let Some(mut block) = content_blocks.remove(index) {
                 // Inject signature into thinking blocks
-                if let MessageContent::Thinking(ref mut t) = block {
-                    if let Some(sig) = signatures.remove(index) {
-                        t.signature = Some(sig);
-                    }
+                if let MessageContent::Thinking(ref mut t) = block
+                    && let Some(sig) = signatures.remove(index)
+                {
+                    t.signature = Some(sig);
                 }
 
                 // Collect tool call requests
@@ -203,24 +206,27 @@ impl AnthropicHandler {
                 match result {
                     Ok((result, tool_use)) => {
                         self.sender
-                            .send(HandlerToLooperMessage::ToolCallComplete(tool_use.id.clone()))
+                            .send(HandlerToLooperMessage::ToolCallComplete(
+                                tool_use.id.clone(),
+                            ))
                             .await?;
 
                         // Push tool result message to history
                         self.messages.push(Message {
                             role: MessageRole::User,
-                            content: MessageContentList(vec![
-                                MessageContent::ToolResult(
-                                    ToolResultBuilder::default()
-                                        .tool_use_id(&tool_use.id)
-                                        .content(result.to_string())
-                                        .build()?
-                                )
-                            ]),
+                            content: MessageContentList(vec![MessageContent::ToolResult(
+                                ToolResultBuilder::default()
+                                    .tool_use_id(&tool_use.id)
+                                    .content(result.to_string())
+                                    .build()?,
+                            )]),
                         });
-                    },
+                    }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -262,9 +268,6 @@ impl StreamingChatHandler for AnthropicHandler {
     }
 
     fn set_tools(&mut self, tools: Vec<LooperToolDefinition>) {
-        self.tools = tools
-            .into_iter()
-            .map(|t| t.into())
-            .collect();
+        self.tools = tools.into_iter().map(|t| t.into()).collect();
     }
 }

--- a/src/services/handlers/anthropic_non_streaming.rs
+++ b/src/services/handlers/anthropic_non_streaming.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use async_anthropic::{
     Client,
     types::{
-        CreateMessagesRequestBuilder, Message, MessageContent, MessageContentList,
-        MessageRole, Thinking, Tool, ToolResultBuilder,
+        CreateMessagesRequestBuilder, Message, MessageContent, MessageContentList, MessageRole,
+        Thinking, Tool, ToolResultBuilder,
     },
 };
 
@@ -108,7 +108,9 @@ impl AnthropicNonStreamingHandler {
             for tool_use in tool_uses {
                 let tr = tr.clone();
                 tool_join_set.spawn(async move {
-                    let result = tr.run_tool(tool_use.name.clone(), tool_use.input.clone()).await;
+                    let result = tr
+                        .run_tool(tool_use.name.clone(), tool_use.input.clone())
+                        .await;
 
                     (result, tool_use)
                 });
@@ -127,22 +129,22 @@ impl AnthropicNonStreamingHandler {
                         // Push tool result message to history
                         self.messages.push(Message {
                             role: MessageRole::User,
-                            content: MessageContentList(vec![
-                                MessageContent::ToolResult(
-                                    ToolResultBuilder::default()
-                                        .tool_use_id(&tool_use.id)
-                                        .content(result.to_string())
-                                        .build()?
-                                )
-                            ]),
+                            content: MessageContentList(vec![MessageContent::ToolResult(
+                                ToolResultBuilder::default()
+                                    .tool_use_id(&tool_use.id)
+                                    .content(result.to_string())
+                                    .build()?,
+                            )]),
                         });
-                    },
+                    }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
-
 
             steps.push(TurnStep {
                 thinking,
@@ -185,10 +187,7 @@ impl ChatHandler for AnthropicNonStreamingHandler {
         let mut steps = Vec::new();
         self.inner_send_message(tools_runner, &mut steps).await?;
 
-        let final_text = steps
-            .iter()
-            .rev()
-            .find_map(|s| s.text.clone());
+        let final_text = steps.iter().rev().find_map(|s| s.text.clone());
 
         let message_history = MessageHistory::Messages(serde_json::to_value(&self.messages)?);
 
@@ -200,9 +199,6 @@ impl ChatHandler for AnthropicNonStreamingHandler {
     }
 
     fn set_tools(&mut self, tools: Vec<LooperToolDefinition>) {
-        self.tools = tools
-            .into_iter()
-            .map(|t| t.into())
-            .collect();
+        self.tools = tools.into_iter().map(|t| t.into()).collect();
     }
 }

--- a/src/services/handlers/gemini.rs
+++ b/src/services/handlers/gemini.rs
@@ -17,7 +17,8 @@ use crate::{
     services::StreamingChatHandler,
     tools::LooperTools,
     types::{
-        HandlerToLooperMessage, HandlerToLooperToolCallRequest, LooperToolDefinition, MessageHistory,
+        HandlerToLooperMessage, HandlerToLooperToolCallRequest, LooperToolDefinition,
+        MessageHistory,
     },
 };
 
@@ -37,7 +38,9 @@ impl GeminiHandler {
     ) -> Result<Self> {
         let api_key = std::env::var("GEMINI_API_KEY")
             .or_else(|_| std::env::var("GOOGLE_API_KEY"))
-            .map_err(|_| anyhow::anyhow!("GEMINI_API_KEY or GOOGLE_API_KEY environment variable must be set"))?;
+            .map_err(|_| {
+                anyhow::anyhow!("GEMINI_API_KEY or GOOGLE_API_KEY environment variable must be set")
+            })?;
 
         let model_id = if model.starts_with("models/") {
             Model::Custom(model.to_string())
@@ -56,11 +59,9 @@ impl GeminiHandler {
     }
 
     #[async_recursion]
-    async fn inner_send_message(
-        &mut self,
-        tools_runner: Arc<dyn LooperTools>,
-    ) -> Result<()> {
-        let mut builder = self.client
+    async fn inner_send_message(&mut self, tools_runner: Arc<dyn LooperTools>) -> Result<()> {
+        let mut builder = self
+            .client
             .generate_content()
             .with_system_prompt(&self.system_message)
             .with_messages(self.messages.clone())
@@ -76,7 +77,8 @@ impl GeminiHandler {
         let mut all_text = String::new();
         let mut thinking_text = String::new();
         // Store function calls with their pre-assigned IDs
-        let mut function_calls: Vec<(gemini_rust::FunctionCall, Option<String>, String)> = Vec::new();
+        let mut function_calls: Vec<(gemini_rust::FunctionCall, Option<String>, String)> =
+            Vec::new();
         let mut had_thinking = false;
 
         while let Some(chunk) = stream.try_next().await? {
@@ -86,7 +88,8 @@ impl GeminiHandler {
                 &mut thinking_text,
                 &mut function_calls,
                 &mut had_thinking,
-            ).await?;
+            )
+            .await?;
         }
 
         if had_thinking {
@@ -162,7 +165,9 @@ impl GeminiHandler {
                 match result {
                     Ok((result, tool_use)) => {
                         self.sender
-                            .send(HandlerToLooperMessage::ToolCallComplete(tool_use.id.clone()))
+                            .send(HandlerToLooperMessage::ToolCallComplete(
+                                tool_use.id.clone(),
+                            ))
                             .await?;
 
                         function_response_parts.push(Part::FunctionResponse {
@@ -173,7 +178,10 @@ impl GeminiHandler {
                         });
                     }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -205,7 +213,11 @@ impl GeminiHandler {
             if let Some(parts) = &candidate.content.parts {
                 for part in parts {
                     match part {
-                        Part::Text { text, thought, thought_signature: _ } => {
+                        Part::Text {
+                            text,
+                            thought,
+                            thought_signature: _,
+                        } => {
                             if *thought == Some(true) {
                                 *had_thinking = true;
                                 thinking_text.push_str(text);
@@ -221,12 +233,19 @@ impl GeminiHandler {
                                     .await?;
                             }
                         }
-                        Part::FunctionCall { function_call, thought_signature } => {
+                        Part::FunctionCall {
+                            function_call,
+                            thought_signature,
+                        } => {
                             let tool_id = uuid::Uuid::new_v4().to_string();
                             self.sender
                                 .send(HandlerToLooperMessage::ToolCallPending(tool_id.clone()))
                                 .await?;
-                            function_calls.push((function_call.clone(), thought_signature.clone(), tool_id));
+                            function_calls.push((
+                                function_call.clone(),
+                                thought_signature.clone(),
+                                tool_id,
+                            ));
                         }
                         _ => {}
                     }

--- a/src/services/handlers/gemini_non_streaming.rs
+++ b/src/services/handlers/gemini_non_streaming.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use gemini_rust::{
-    Content, FunctionResponse, Gemini, Message, Model, Part, Role, Tool,
-};
+use gemini_rust::{Content, FunctionResponse, Gemini, Message, Model, Part, Role, Tool};
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -31,7 +29,9 @@ impl GeminiNonStreamingHandler {
     pub fn new(model: &str, system_message: &str) -> Result<Self> {
         let api_key = std::env::var("GEMINI_API_KEY")
             .or_else(|_| std::env::var("GOOGLE_API_KEY"))
-            .map_err(|_| anyhow::anyhow!("GEMINI_API_KEY or GOOGLE_API_KEY environment variable must be set"))?;
+            .map_err(|_| {
+                anyhow::anyhow!("GEMINI_API_KEY or GOOGLE_API_KEY environment variable must be set")
+            })?;
 
         let model_id = if model.starts_with("models/") {
             Model::Custom(model.to_string())
@@ -54,7 +54,8 @@ impl GeminiNonStreamingHandler {
         tools_runner: Arc<dyn LooperTools>,
         steps: &mut Vec<TurnStep>,
     ) -> Result<()> {
-        let mut builder = self.client
+        let mut builder = self
+            .client
             .generate_content()
             .with_system_prompt(&self.system_message)
             .with_messages(self.messages.clone())
@@ -76,17 +77,22 @@ impl GeminiNonStreamingHandler {
             if let Some(parts) = &candidate.content.parts {
                 for part in parts {
                     match part {
-                        Part::Text { text: t, thought, thought_signature: _ } => {
+                        Part::Text {
+                            text: t,
+                            thought,
+                            thought_signature: _,
+                        } => {
                             if *thought == Some(true) {
-                                thinking.push(ThinkingBlock {
-                                    content: t.clone(),
-                                });
+                                thinking.push(ThinkingBlock { content: t.clone() });
                             } else {
                                 text = Some(t.clone());
                             }
                             assistant_parts.push(part.clone());
                         }
-                        Part::FunctionCall { function_call, thought_signature } => {
+                        Part::FunctionCall {
+                            function_call,
+                            thought_signature,
+                        } => {
                             func_calls.push((function_call.clone(), thought_signature.clone()));
                             assistant_parts.push(part.clone());
                         }
@@ -145,7 +151,10 @@ impl GeminiNonStreamingHandler {
                         });
                     }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -197,10 +206,7 @@ impl ChatHandler for GeminiNonStreamingHandler {
         let mut steps = Vec::new();
         self.inner_send_message(tools_runner, &mut steps).await?;
 
-        let final_text = steps
-            .iter()
-            .rev()
-            .find_map(|s| s.text.clone());
+        let final_text = steps.iter().rev().find_map(|s| s.text.clone());
 
         let message_history = MessageHistory::Messages(serde_json::to_value(&self.messages)?);
 

--- a/src/services/handlers/openai_completions.rs
+++ b/src/services/handlers/openai_completions.rs
@@ -5,11 +5,10 @@ use async_openai::{
     config::OpenAIConfig,
     types::chat::{
         ChatCompletionMessageToolCall, ChatCompletionMessageToolCalls,
-        ChatCompletionRequestAssistantMessage,
-        ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
-        ChatCompletionRequestToolMessage, ChatCompletionRequestUserMessageArgs,
-        ChatCompletionTools, CreateChatCompletionRequestArgs, FinishReason,
-        ReasoningEffort,
+        ChatCompletionRequestAssistantMessage, ChatCompletionRequestMessage,
+        ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestToolMessage,
+        ChatCompletionRequestUserMessageArgs, ChatCompletionTools, CreateChatCompletionRequestArgs,
+        FinishReason, ReasoningEffort,
     },
 };
 
@@ -22,9 +21,14 @@ use tokio::task::JoinSet;
 
 use serde_json::Value;
 
-use crate::{services::StreamingChatHandler, tools::LooperTools, types::{
-    HandlerToLooperMessage, HandlerToLooperToolCallRequest, LooperToolDefinition, MessageHistory,
-}};
+use crate::{
+    services::StreamingChatHandler,
+    tools::LooperTools,
+    types::{
+        HandlerToLooperMessage, HandlerToLooperToolCallRequest, LooperToolDefinition,
+        MessageHistory,
+    },
+};
 
 pub struct OpenAIChatHandler {
     client: Client<OpenAIConfig>,
@@ -59,10 +63,7 @@ impl OpenAIChatHandler {
     }
 
     #[async_recursion]
-    async fn inner_send_message(
-        &mut self,
-        tools_runner: Arc<dyn LooperTools>,
-    ) -> Result<String> {
+    async fn inner_send_message(&mut self, tools_runner: Arc<dyn LooperTools>) -> Result<String> {
         let request = CreateChatCompletionRequestArgs::default()
             .model(&self.model)
             .max_completion_tokens(50000u32)
@@ -117,7 +118,9 @@ impl OpenAIChatHandler {
                                 }
 
                                 self.sender
-                                    .send(HandlerToLooperMessage::ToolCallPending(tool_calls[index].id.clone()))
+                                    .send(HandlerToLooperMessage::ToolCallPending(
+                                        tool_calls[index].id.clone(),
+                                    ))
                                     .await?;
                             }
                         }
@@ -139,8 +142,9 @@ impl OpenAIChatHandler {
                                 let tr = tools_runner.clone();
                                 let tc_id = tool_call.id.clone();
                                 let tc_name = tool_call.function.name.clone();
-                                let tc_args: Value = serde_json::from_str(&tool_call.function.arguments)
-                                    .unwrap_or_default();
+                                let tc_args: Value =
+                                    serde_json::from_str(&tool_call.function.arguments)
+                                        .unwrap_or_default();
 
                                 tool_join_set.spawn(async move {
                                     let result = tr.run_tool(tc_name, tc_args).await;
@@ -175,7 +179,9 @@ impl OpenAIChatHandler {
                 match result {
                     Ok((tool_call_id, response)) => {
                         self.sender
-                            .send(HandlerToLooperMessage::ToolCallComplete(tool_call_id.clone()))
+                            .send(HandlerToLooperMessage::ToolCallComplete(
+                                tool_call_id.clone(),
+                            ))
                             .await?;
 
                         self.messages.push(
@@ -185,9 +191,12 @@ impl OpenAIChatHandler {
                             }
                             .into(),
                         );
-                    },
+                    }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }

--- a/src/services/handlers/openai_completions_non_streaming.rs
+++ b/src/services/handlers/openai_completions_non_streaming.rs
@@ -4,12 +4,10 @@ use async_openai::{
     Client,
     config::OpenAIConfig,
     types::chat::{
-        ChatCompletionMessageToolCalls,
-        ChatCompletionRequestAssistantMessage,
+        ChatCompletionMessageToolCalls, ChatCompletionRequestAssistantMessage,
         ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
         ChatCompletionRequestToolMessage, ChatCompletionRequestUserMessageArgs,
-        ChatCompletionTools, CreateChatCompletionRequestArgs, FinishReason,
-        ReasoningEffort,
+        ChatCompletionTools, CreateChatCompletionRequestArgs, FinishReason, ReasoningEffort,
     },
 };
 
@@ -109,9 +107,11 @@ impl OpenAINonStreamingChatHandler {
 
                 let tr = tr.clone();
                 tool_join_set.spawn(async move {
-                    let args: Value = serde_json::from_str(&func_call.function.arguments)
-                        .unwrap_or_default();
-                    let result = tr.run_tool(func_call.function.name.clone(), args.clone()).await;
+                    let args: Value =
+                        serde_json::from_str(&func_call.function.arguments).unwrap_or_default();
+                    let result = tr
+                        .run_tool(func_call.function.name.clone(), args.clone())
+                        .await;
 
                     (result, func_call, args)
                 });
@@ -135,9 +135,12 @@ impl OpenAINonStreamingChatHandler {
                             }
                             .into(),
                         );
-                    },
+                    }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -195,10 +198,7 @@ impl ChatHandler for OpenAINonStreamingChatHandler {
         let mut steps = Vec::new();
         self.inner_send_message(tools_runner, &mut steps).await?;
 
-        let final_text = steps
-            .iter()
-            .rev()
-            .find_map(|s| s.text.clone());
+        let final_text = steps.iter().rev().find_map(|s| s.text.clone());
 
         let message_history = MessageHistory::Messages(serde_json::to_value(&self.messages)?);
 

--- a/src/services/handlers/openai_responses.rs
+++ b/src/services/handlers/openai_responses.rs
@@ -3,11 +3,14 @@ use std::sync::Arc;
 use async_openai::{
     Client,
     config::OpenAIConfig,
-    types::{chat::ReasoningEffort, responses::{
-        CreateResponseArgs, FunctionCallOutput, FunctionCallOutputItemParam, FunctionToolCall,
-        InputItem, InputParam, Item, OutputItem, Reasoning, ReasoningSummary,
-        ResponseStreamEvent, Tool,
-    }},
+    types::{
+        chat::ReasoningEffort,
+        responses::{
+            CreateResponseArgs, FunctionCallOutput, FunctionCallOutputItemParam, FunctionToolCall,
+            InputItem, InputParam, Item, OutputItem, Reasoning, ReasoningSummary,
+            ResponseStreamEvent, Tool,
+        },
+    },
 };
 
 use async_recursion::async_recursion;
@@ -108,7 +111,9 @@ impl OpenAIResponsesHandler {
                 }
                 Ok(ResponseStreamEvent::ResponseFunctionCallArgumentsDelta(delta)) => {
                     self.sender
-                        .send(HandlerToLooperMessage::ToolCallPending(delta.item_id.clone()))
+                        .send(HandlerToLooperMessage::ToolCallPending(
+                            delta.item_id.clone(),
+                        ))
                         .await?;
                 }
                 Ok(ResponseStreamEvent::ResponseOutputItemDone(item_done)) => {
@@ -126,8 +131,8 @@ impl OpenAIResponsesHandler {
                         let tr = tools_runner.clone();
                         let fc_clone = fc.clone();
                         tool_join_set.spawn(async move {
-                            let args: Value = serde_json::from_str(&fc_clone.arguments)
-                                .unwrap_or_default();
+                            let args: Value =
+                                serde_json::from_str(&fc_clone.arguments).unwrap_or_default();
                             let result = tr.run_tool(fc_clone.name.clone(), args).await;
                             (fc_clone.call_id.clone(), result)
                         });
@@ -168,14 +173,19 @@ impl OpenAIResponsesHandler {
                                 status: None,
                             },
                         )));
-                    },
+                    }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
 
-            return self.inner_send_message(Some(InputParam::Items(input_items)), tools_runner).await;
+            return self
+                .inner_send_message(Some(InputParam::Items(input_items)), tools_runner)
+                .await;
         }
 
         Ok(assistant_res_buf.join(""))

--- a/src/services/handlers/openai_responses_non_streaming.rs
+++ b/src/services/handlers/openai_responses_non_streaming.rs
@@ -3,10 +3,13 @@ use std::sync::Arc;
 use async_openai::{
     Client,
     config::OpenAIConfig,
-    types::{chat::ReasoningEffort, responses::{
-        CreateResponseArgs, FunctionCallOutput, FunctionCallOutputItemParam,
-        InputItem, InputParam, Item, OutputItem, Reasoning, ReasoningSummary, Tool,
-    }},
+    types::{
+        chat::ReasoningEffort,
+        responses::{
+            CreateResponseArgs, FunctionCallOutput, FunctionCallOutputItemParam, InputItem,
+            InputParam, Item, OutputItem, Reasoning, ReasoningSummary, Tool,
+        },
+    },
 };
 
 use async_recursion::async_recursion;
@@ -92,7 +95,9 @@ impl OpenAIResponsesNonStreamingHandler {
                 }
                 OutputItem::Message(m) => {
                     for content in &m.content {
-                        if let async_openai::types::responses::OutputMessageContent::OutputText(t) = content {
+                        if let async_openai::types::responses::OutputMessageContent::OutputText(t) =
+                            content
+                        {
                             text = Some(t.text.clone());
                         }
                     }
@@ -115,8 +120,8 @@ impl OpenAIResponsesNonStreamingHandler {
             for fc in function_calls {
                 let tr = tr.clone();
                 tool_join_set.spawn(async move {
-                    let args: serde_json::Value = serde_json::from_str(&fc.arguments)
-                        .unwrap_or_default();
+                    let args: serde_json::Value =
+                        serde_json::from_str(&fc.arguments).unwrap_or_default();
                     let result = tr.run_tool(fc.name.clone(), args.clone()).await;
 
                     (result, fc, args)
@@ -141,9 +146,12 @@ impl OpenAIResponsesNonStreamingHandler {
                                 status: None,
                             },
                         )));
-                    },
+                    }
                     Err(e) => {
-                        eprintln!("Join Error occured when collecting tool call results | Error: {}", e);
+                        eprintln!(
+                            "Join Error occured when collecting tool call results | Error: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -190,9 +198,8 @@ impl ChatHandler for OpenAIResponsesNonStreamingHandler {
 
         let final_text = steps.iter().rev().find_map(|s| s.text.clone());
 
-        let message_history = MessageHistory::ResponseId(
-            self.previous_response_id.clone().unwrap_or_default(),
-        );
+        let message_history =
+            MessageHistory::ResponseId(self.previous_response_id.clone().unwrap_or_default());
 
         Ok(TurnResult {
             steps,

--- a/src/tools/empty.rs
+++ b/src/tools/empty.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use crate::{tools::{LooperTool, LooperTools}, types::LooperToolDefinition};
+use crate::{
+    tools::{LooperTool, LooperTools},
+    types::LooperToolDefinition,
+};
 
 pub struct EmptyToolSet;
 

--- a/src/tools/sub_agent.rs
+++ b/src/tools/sub_agent.rs
@@ -16,7 +16,9 @@ impl SubAgentTool {
 
 #[async_trait]
 impl LooperTool for SubAgentTool {
-    fn get_tool_name(&self) -> String { "spawn_sub_agent".to_string() }
+    fn get_tool_name(&self) -> String {
+        "spawn_sub_agent".to_string()
+    }
 
     fn tool(&self) -> LooperToolDefinition {
         LooperToolDefinition::default()
@@ -37,15 +39,15 @@ impl LooperTool for SubAgentTool {
     }
 
     async fn execute(&mut self, args: &Value) -> Value {
-        let Some(task_description) = args["task_description"]
-            .as_str()
-        else {
+        let Some(task_description) = args["task_description"].as_str() else {
             return json!({ "error": "Missing 'task_description' argument" });
         };
 
-        let result = match self.looper.send(&task_description).await {
+        let result = match self.looper.send(task_description).await {
             Ok(r) => r,
-            Err(e) => return json!({ "error": format!("An error occured when sending message | Error: {}", e) })
+            Err(e) => {
+                return json!({ "error": format!("An error occured when sending message | Error: {}", e) });
+            }
         };
 
         match &result.final_text {

--- a/src/types/messages.rs
+++ b/src/types/messages.rs
@@ -12,7 +12,7 @@ pub enum HandlerToLooperMessage {
     ToolCallPending(ToolId),
     ToolCallRequest(HandlerToLooperToolCallRequest),
     ToolCallComplete(ToolId),
-    TurnComplete
+    TurnComplete,
 }
 
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ pub struct HandlerToLooperToolCallRequest {
 #[derive(Debug)]
 pub struct LooperToHandlerToolCallResult {
     pub id: String,
-    pub value: Value
+    pub value: Value,
 }
 
 #[derive(Debug)]
@@ -36,5 +36,5 @@ pub enum LooperToInterfaceMessage {
     ToolCallPending(ToolId),
     ToolCall(Name),
     ToolCallComplete(ToolId),
-    TurnComplete
+    TurnComplete,
 }

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -4,12 +4,16 @@ use serde_json::{Value, json};
 pub struct LooperToolDefinition {
     pub name: String,
     pub description: String,
-    pub parameters: Value
+    pub parameters: Value,
 }
 
 impl Default for LooperToolDefinition {
     fn default() -> Self {
-        LooperToolDefinition { name: "".to_string(), description: "".to_string(), parameters: json!({}) }
+        LooperToolDefinition {
+            name: "".to_string(),
+            description: "".to_string(),
+            parameters: json!({}),
+        }
     }
 }
 

--- a/src/types/turn.rs
+++ b/src/types/turn.rs
@@ -1,5 +1,5 @@
-use serde_json::Value;
 use super::MessageHistory;
+use serde_json::Value;
 
 pub struct ThinkingBlock {
     pub content: String,


### PR DESCRIPTION
prep for ask user tool,  lots of diffs due to linters etc 

## Summary
- fix the clippy warnings that were failing the cargo-husky pre-push hook
- apply cargo fmt across the repo so the formatter check passes cleanly

## Testing
- .git/hooks/pre-push
