### PR TITLE
Draft: add minimal ask_user tool shape

### DIFF
--- a/src/looper.rs
+++ b/src/looper.rs
@@ -13,8 +13,8 @@ use crate::{
             openai_responses_non_streaming::OpenAIResponsesNonStreamingHandler,
         },
     },
-    tools::{EmptyToolSet, LooperTools, SubAgentTool},
-    types::{Handlers, MessageHistory, turn::TurnResult},
+    tools::{AskUserTool, CompositeToolSet, LooperTools, SubAgentTool},
+    types::{AskUserSender, Handlers, MessageHistory, turn::TurnResult},
 };
 
 pub struct Looper {
@@ -29,6 +29,7 @@ pub struct LooperBuilder<'a> {
     tools: Option<Box<dyn LooperTools>>,
     instructions: Option<String>,
     sub_agent: Option<Looper>,
+    ask_user_channel: Option<AskUserSender>,
 }
 
 impl<'a> LooperBuilder<'a> {
@@ -57,8 +58,26 @@ impl<'a> LooperBuilder<'a> {
         self
     }
 
+    pub fn ask_user_channel(mut self, channel: AskUserSender) -> Self {
+        self.ask_user_channel = Some(channel);
+        self
+    }
+
     pub async fn build(mut self) -> Result<Looper> {
         let sub_agent_enabled = self.sub_agent.is_some();
+        let mut tool_set = CompositeToolSet::new(self.tools.take());
+
+        if let Some(sub_agent) = self.sub_agent.take() {
+            tool_set
+                .add_tool(Arc::new(SubAgentTool::new(sub_agent)))
+                .await;
+        }
+
+        if let Some(channel) = self.ask_user_channel.take() {
+            tool_set.add_tool(Arc::new(AskUserTool::new(channel))).await;
+        }
+
+        let tool_definitions = tool_set.get_tools().await;
 
         let handler: Box<dyn ChatHandler> = match self.handler_type {
             Handlers::Anthropic(m) => {
@@ -66,15 +85,7 @@ impl<'a> LooperBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
             Handlers::OpenAICompletions(m) => {
@@ -82,15 +93,7 @@ impl<'a> LooperBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
             Handlers::OpenAIResponses(m) => {
@@ -98,15 +101,7 @@ impl<'a> LooperBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
             Handlers::Gemini(m) => {
@@ -114,31 +109,16 @@ impl<'a> LooperBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
         };
 
-        match self.tools {
-            Some(t) => Ok(Looper {
-                handler,
-                message_history: self.message_history,
-                tools: Arc::from(t),
-            }),
-            None => Ok(Looper {
-                handler,
-                message_history: self.message_history,
-                tools: Arc::new(EmptyToolSet),
-            }),
-        }
+        Ok(Looper {
+            handler,
+            message_history: self.message_history,
+            tools: Arc::new(tool_set),
+        })
     }
 }
 
@@ -150,6 +130,7 @@ impl Looper {
             tools: None,
             sub_agent: None,
             instructions: None,
+            ask_user_channel: None,
         }
     }
 

--- a/src/looper_stream.rs
+++ b/src/looper_stream.rs
@@ -8,8 +8,10 @@ use crate::{
         StreamingChatHandler, anthropic::AnthropicHandler, gemini::GeminiHandler,
         openai_completions::OpenAIChatHandler, openai_responses::OpenAIResponsesHandler,
     },
-    tools::{EmptyToolSet, LooperTools, SubAgentTool},
-    types::{HandlerToLooperMessage, Handlers, LooperToInterfaceMessage, MessageHistory},
+    tools::{AskUserTool, CompositeToolSet, LooperTools, SubAgentTool},
+    types::{
+        AskUserSender, HandlerToLooperMessage, Handlers, LooperToInterfaceMessage, MessageHistory,
+    },
 };
 use anyhow::Result;
 use tera::{Context, Tera};
@@ -29,6 +31,7 @@ pub struct LooperStreamBuilder<'a> {
     tools: Option<Box<dyn LooperTools>>,
     instructions: Option<String>,
     sub_agent: Option<Looper>,
+    ask_user_channel: Option<AskUserSender>,
     buffered_output: bool,
 }
 
@@ -58,6 +61,11 @@ impl<'a> LooperStreamBuilder<'a> {
         self
     }
 
+    pub fn ask_user_channel(mut self, channel: AskUserSender) -> Self {
+        self.ask_user_channel = Some(channel);
+        self
+    }
+
     pub fn buffered_output(mut self) -> Self {
         self.buffered_output = true;
         self
@@ -67,6 +75,19 @@ impl<'a> LooperStreamBuilder<'a> {
         let sub_agent_enabled = self.sub_agent.is_some();
         let (handler_looper_sender, mut handler_looper_receiver) = mpsc::channel(10000);
         let (looper_ui_sender, looper_ui_receiver) = mpsc::channel(10000);
+        let mut tool_set = CompositeToolSet::new(self.tools.take());
+
+        if let Some(sub_agent) = self.sub_agent.take() {
+            tool_set
+                .add_tool(Arc::new(SubAgentTool::new(sub_agent)))
+                .await;
+        }
+
+        if let Some(channel) = self.ask_user_channel.take() {
+            tool_set.add_tool(Arc::new(AskUserTool::new(channel))).await;
+        }
+
+        let tool_definitions = tool_set.get_tools().await;
 
         let handler: Box<dyn StreamingChatHandler> = match self.handler_type {
             Handlers::OpenAICompletions(m) => {
@@ -75,15 +96,7 @@ impl<'a> LooperStreamBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
             Handlers::OpenAIResponses(m) => {
@@ -92,15 +105,7 @@ impl<'a> LooperStreamBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
             Handlers::Anthropic(m) => {
@@ -109,15 +114,7 @@ impl<'a> LooperStreamBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
             Handlers::Gemini(m) => {
@@ -126,15 +123,7 @@ impl<'a> LooperStreamBuilder<'a> {
                     m,
                     &get_system_message(self.instructions.as_deref(), sub_agent_enabled)?,
                 )?;
-
-                if let Some(t) = self.tools.as_mut() {
-                    if let Some(sa) = self.sub_agent {
-                        let agent_tools = Arc::new(SubAgentTool::new(sa));
-                        let _ = t.add_tool(agent_tools).await;
-                    }
-                    handler.set_tools(t.get_tools().await);
-                }
-
+                handler.set_tools(tool_definitions.clone());
                 Box::new(handler)
             }
         };
@@ -196,24 +185,13 @@ impl<'a> LooperStreamBuilder<'a> {
             }
         });
 
-        match self.tools {
-            Some(t) => {
-                let ls = LooperStream {
-                    handler,
-                    message_history: self.message_history,
-                    tools: Arc::from(t),
-                };
-                Ok((ls, looper_ui_receiver))
-            }
-            None => {
-                let ls = LooperStream {
-                    handler,
-                    message_history: self.message_history,
-                    tools: Arc::new(EmptyToolSet),
-                };
-                Ok((ls, looper_ui_receiver))
-            }
-        }
+        let ls = LooperStream {
+            handler,
+            message_history: self.message_history,
+            tools: Arc::new(tool_set),
+        };
+
+        Ok((ls, looper_ui_receiver))
     }
 }
 
@@ -225,7 +203,7 @@ impl LooperStream {
             tools: None,
             sub_agent: None,
             instructions: None,
-            // interface_sender: None,
+            ask_user_channel: None,
             buffered_output: false,
         }
     }

--- a/src/tools/ask_user.rs
+++ b/src/tools/ask_user.rs
@@ -1,0 +1,85 @@
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::{
+    tools::LooperTool,
+    types::{AskUserRequest, LooperToolDefinition},
+};
+
+pub struct AskUserTool {
+    sender: crate::types::AskUserSender,
+}
+
+impl AskUserTool {
+    pub const NAME: &'static str = "ask_user";
+
+    pub fn new(sender: crate::types::AskUserSender) -> Self {
+        AskUserTool { sender }
+    }
+}
+
+#[async_trait]
+impl LooperTool for AskUserTool {
+    fn get_tool_name(&self) -> String {
+        Self::NAME.to_string()
+    }
+
+    fn tool(&self) -> LooperToolDefinition {
+        LooperToolDefinition::default()
+            .set_name(Self::NAME)
+            .set_description(
+                "Ask the human user a blocking question when you need input to continue. IMPORTANT: call this tool alone, never in the same assistant turn as any other tool.",
+            )
+            .set_paramters(json!({
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The exact question to show the user."
+                    },
+                    "options": {
+                        "type": "array",
+                        "description": "Optional suggested answer choices to show the user.",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["question"]
+            }))
+    }
+
+    async fn execute(&mut self, args: &Value) -> Value {
+        let Some(question) = args.get("question").and_then(Value::as_str) else {
+            return json!({ "error": "Missing 'question' argument" });
+        };
+
+        let options = args
+            .get("options")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str().map(ToString::to_string))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let (response_tx, response_rx) = oneshot::channel();
+        let request = AskUserRequest {
+            id: Uuid::new_v4().to_string(),
+            question: question.to_string(),
+            options,
+            response_tx,
+        };
+
+        if self.sender.send(request).await.is_err() {
+            return json!({ "error": "ask_user channel is closed" });
+        }
+
+        match response_rx.await {
+            Ok(response) => json!({ "answer": response.answer }),
+            Err(_) => json!({ "error": "ask_user response channel was dropped" }),
+        }
+    }
+}

--- a/src/tools/handler.rs
+++ b/src/tools/handler.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+use crate::{
+    tools::{LooperTool, LooperTools},
+    types::LooperToolDefinition,
+};
+
+pub struct CompositeToolSet {
+    base: Option<Box<dyn LooperTools>>,
+    injected: HashMap<String, Mutex<Arc<dyn LooperTool>>>,
+}
+
+impl CompositeToolSet {
+    pub fn new(base: Option<Box<dyn LooperTools>>) -> Self {
+        CompositeToolSet {
+            base,
+            injected: HashMap::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl LooperTools for CompositeToolSet {
+    async fn get_tools(&self) -> Vec<LooperToolDefinition> {
+        let mut tools = if let Some(base) = &self.base {
+            base.get_tools().await
+        } else {
+            Vec::new()
+        };
+
+        tools.retain(|tool| !self.injected.contains_key(&tool.name));
+
+        for registered in self.injected.values() {
+            let guard = registered.lock().await;
+            tools.push(guard.tool().clone());
+        }
+
+        tools
+    }
+
+    async fn add_tool(&mut self, tool: Arc<dyn LooperTool>) {
+        let tool_name = tool.get_tool_name();
+        self.injected.insert(tool_name, Mutex::new(tool));
+    }
+
+    async fn run_tool(&self, name: String, args: Value) -> Value {
+        if let Some(registered) = self.injected.get(&name) {
+            let mut guard = registered.lock().await;
+            let tool = Arc::get_mut(&mut guard)
+                .expect("tool has multiple references; injected tools must be uniquely owned");
+
+            return tool.execute(&args).await;
+        }
+
+        if let Some(base) = &self.base {
+            return base.run_tool(name, args).await;
+        }
+
+        json!({ "error": format!("Unknown function: {}", name) })
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,9 @@
+pub mod ask_user;
+pub use ask_user::*;
+
+pub mod handler;
+pub use handler::*;
+
 pub mod sub_agent;
 pub use sub_agent::*;
 

--- a/src/types/ask_user.rs
+++ b/src/types/ask_user.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+use tokio::sync::{mpsc, oneshot};
+
+pub type AskUserSender = mpsc::Sender<AskUserRequest>;
+
+pub struct AskUserRequest {
+    pub id: String,
+    pub question: String,
+    pub options: Vec<String>,
+    pub response_tx: oneshot::Sender<AskUserResponse>,
+}
+
+impl fmt::Debug for AskUserRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AskUserRequest")
+            .field("id", &self.id)
+            .field("question", &self.question)
+            .field("options", &self.options)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+pub struct AskUserResponse {
+    pub answer: String,
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,6 @@
+pub mod ask_user;
+pub use ask_user::*;
+
 pub mod messages;
 pub use messages::*;
 


### PR DESCRIPTION
This is a draft PR to show the shape of a minimal `ask_user` tool integration.

Scope in this draft:
- add `AskUserRequest` / `AskUserSender` types
- add the built-in `ask_user` tool
- add a small injected tool registry so built-in tools can be attached without changing provider handlers
- wire `ask_user_channel(...)` into `Looper` and `LooperStream`

This is meant to keep the patch small and make the feature's shape easy to review first.

I got an example working here https://github.com/alchemiststudiosDOTai/looper-rs/tree/asktool


<img width="1742" height="971" alt="SCR-20260412-qtqe" src="https://github.com/user-attachments/assets/44fcb634-0cc8-4415-8c6f-2f5988c1ae14" />
